### PR TITLE
claude/rollback-plytix-mcp-bimqI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Plytix MCP Server
 
-A **Model Context Protocol (MCP) server** that provides AI assistants with access to Plytix PIM (Product Information Management) data. This server enables AI tools like Claude Desktop to read, search, and manage product information, assets, categories, and variants through a standardized interface.
+A **lightweight, stateless Model Context Protocol (MCP) server** that provides AI assistants with live access to Plytix PIM (Product Information Management) data. This server enables AI tools like Claude Desktop to search, look up, and retrieve product information directly from the Plytix API.
+
+> **Note:** This is a read-only query tool for live API access. For sync, caching, or ETL workflows, see [supplyline-sync](https://github.com/Supplyline/supplyline-sync).
 
 ## Features
 
-- **5 MCP Tools** for comprehensive Plytix PIM access:
-  - `products.get` — Fetch individual products by ID
-  - `products.search` — Search products with filters and pagination
-  - `assets.list` — List product assets (images, videos, etc.)
-  - `categories.list` — List product categories
-  - `variants.list` — List product variants
+- **11 MCP Tools** for comprehensive Plytix PIM access
+- **Smart product lookup** with automatic identifier detection (SKU, MPN, GTIN, label)
+- **Family & inheritance tracking** with overwritten_attributes support
+- **Schema discovery** for attributes and search filters
 - **Automatic authentication** with token refresh
-- **Error handling** with detailed error messages
-- **TypeScript** with full type safety
-- **Production ready** with proper logging and validation
+- **Rate limit handling** with exponential backoff
+- **Zero persistence** — stateless, no database required
 
 ## Installation
 
@@ -46,7 +45,7 @@ npm run build
 
 ### With Claude Desktop
 
-Add this to your Claude Desktop MCP configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+Add to your Claude Desktop MCP configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
@@ -63,105 +62,78 @@ Add this to your Claude Desktop MCP configuration (`~/Library/Application Suppor
 }
 ```
 
-### With other MCP clients
-
-The server communicates via **stdio** using the MCP protocol. Start it with:
+### Standalone
 
 ```bash
-npm start
-# or for development:
-npm run dev
-```
-
-### Testing
-
-Run the integration tests to verify everything works:
-
-```bash
-# Test with dummy credentials (expects auth failures)
-npm test
-
-# Test MCP protocol handshake
-npm run test:mcp
-
-# Run all tests
-npm run test:all
+npm start          # Production mode
+npm run dev        # Development with hot reload
 ```
 
 ## Available Tools
 
-### products.get
-Fetch a single product by its ID.
+### Product Tools
 
-**Input:**
-```json
-{
-  "product_id": "your-product-id-here"
-}
-```
+| Tool | Description |
+|------|-------------|
+| `products_lookup` | Smart lookup by any identifier (auto-detects ID, SKU, MPN, GTIN, label) |
+| `products_get` | Get single product by ID with full details and `overwritten_attributes` |
+| `products_search` | Advanced search with filters, pagination, and sorting |
+| `products_find` | Simple multi-criteria search (SKU, MPN, MNO, GTIN, label, fuzzy) |
+
+### Family Tools
+
+| Tool | Description |
+|------|-------------|
+| `families_list` | List or search product families |
+| `families_get` | Get single family with linked attributes |
+
+### Attribute Tools
+
+| Tool | Description |
+|------|-------------|
+| `attributes_list` | List all attributes (system + custom) with types and options |
+| `attributes_filters` | Get available search filters and operators |
+
+### Related Data Tools
+
+| Tool | Description |
+|------|-------------|
+| `assets_list` | List assets (images, videos, documents) linked to a product |
+| `categories_list` | List categories associated with a product |
+| `variants_list` | List variants for a product |
+
+## Smart Lookup System
+
+The `products_lookup` tool automatically detects identifier types and uses staged search strategies:
+
+**Detection priority:**
+1. MongoDB ObjectId (24-char hex) → `id` (confidence: 1.0)
+2. GTIN (8/12/13/14 digits) → `gtin` (confidence: 0.95)
+3. Contains spaces → `label` (confidence: 0.9)
+4. Dashed alphanumeric → `mpn` (confidence: 0.8)
+5. Alphanumeric with separators → `sku` (confidence: 0.7)
+
+**Search strategies (in order):**
+1. Direct ID lookup (if detected as ID)
+2. Exact field matches (SKU, GTIN, MPN, MNO)
+3. Text search across multiple fields
+4. Broad LIKE search (last resort)
 
 **Example:**
-```json
-{
-  "product_id": "64f8a1b2c3d4e5f6a7b8c9d0"
-}
+```
+Input: "LMI-PD-123"
+→ Detected as: sku (confidence: 0.7)
+→ Tries: sku_eq, mpn fields, text_search, broad_like
+→ Returns: best match with confidence score
 ```
 
-### products.search
-Search products with filters, pagination, and attribute selection.
+## Inheritance Tracking
 
-**Input:**
-```json
-{
-  "attributes": ["sku", "label", "attributes.color", "attributes.size"],
-  "filters": [
-    [{ "field": "modified", "operator": "last_days", "value": "30" }]
-  ],
-  "pagination": {
-    "page": 1,
-    "page_size": 25
-  },
-  "sort": {
-    "field": "modified",
-    "order": "desc"
-  }
-}
-```
+Products return an `overwritten_attributes` array listing which attributes are explicitly set (not inherited from family). Use this with:
 
-**Notes:**
-- Prefix custom attributes with `attributes.`
-- Maximum 50 attributes allowed
-- Use product-specific endpoints for assets, categories, and variants
-
-### assets.list
-List all assets (images, videos, documents) linked to a product.
-
-**Input:**
-```json
-{
-  "product_id": "your-product-id-here"
-}
-```
-
-### categories.list
-List all categories associated with a product.
-
-**Input:**
-```json
-{
-  "product_id": "your-product-id-here"
-}
-```
-
-### variants.list
-List all variants (size, color, etc.) for a product.
-
-**Input:**
-```json
-{
-  "product_id": "your-product-id-here"
-}
-```
+- `product_family_id` — The family this product belongs to
+- `families_get` — Retrieve family-level default values
+- Compare to determine inherited vs overwritten values
 
 ## Configuration
 
@@ -169,67 +141,65 @@ List all variants (size, color, etc.) for a product.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PLYTIX_API_KEY` | ✅ | - | Your Plytix API key |
-| `PLYTIX_API_PASSWORD` | ✅ | - | Your Plytix API password |
+| `PLYTIX_API_KEY` | ✅ | — | Your Plytix API key |
+| `PLYTIX_API_PASSWORD` | ✅ | — | Your Plytix API password |
 | `PLYTIX_API_BASE` | ❌ | `https://pim.plytix.com` | Plytix API base URL |
-| `PLYTIX_AUTH_URL` | ❌ | `https://auth.plytix.com/auth/api/get-token` | Authentication endpoint |
-
-### Example .env file
-
-```bash
-PLYTIX_API_KEY=your_api_key_here
-PLYTIX_API_PASSWORD=your_api_password_here
-# Optional overrides:
-# PLYTIX_API_BASE=https://pim.plytix.com
-# PLYTIX_AUTH_URL=https://auth.plytix.com/auth/api/get-token
-```
+| `PLYTIX_AUTH_URL` | ❌ | `https://auth.plytix.com/auth/api/get-token` | Auth endpoint |
+| `PLYTIX_MPN_LABELS` | ❌ | `["attributes.mpn"]` | JSON array of MPN attribute labels |
+| `PLYTIX_MNO_LABELS` | ❌ | `["attributes.model_no"]` | JSON array of MNO attribute labels |
 
 ## Development
 
 ### Scripts
 
-- `npm run dev` - Start development server with hot reload
-- `npm run build` - Build TypeScript to JavaScript
-- `npm start` - Start production server
-- `npm test` - Run integration tests
-- `npm run test:mcp` - Test MCP protocol handshake
-- `npm run test:all` - Run all tests
-- `npm run typecheck` - Type check without building
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Development server with hot reload |
+| `npm run build` | Build TypeScript to JavaScript |
+| `npm start` | Start production server |
+| `npm test` | Run unit tests (vitest) |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:mcp` | Test MCP protocol handshake |
+| `npm run test:all` | Build + unit + integration + MCP tests |
+| `npm run typecheck` | Type check without building |
 
 ### Architecture
 
-- **`src/index.ts`** - Main server entry point
-- **`src/plytixClient.ts`** - Plytix API client with auth handling
-- **`src/tools/`** - MCP tool implementations
-  - `products.ts` - Product-related tools
-  - `assets.ts` - Asset management tools
-  - `categories.ts` - Category tools
-  - `variants.ts` - Product variant tools
+```
+src/
+  index.ts              # MCP server entry point
+  client.ts             # Plytix API client with auth & rate limiting
+  types.ts              # TypeScript types
+  lookup/
+    identifier.ts       # Identifier type detection
+    lookup.ts           # Smart lookup with staged search
+  tools/
+    products.ts         # Product tools (lookup, get, search, find)
+    families.ts         # Family tools (list, get)
+    attributes.ts       # Attribute tools (list, filters)
+    assets.ts           # Asset listing
+    categories.ts       # Category listing
+    variants.ts         # Variant listing
+  supplyline/           # Supplyline-specific customizations
+```
 
-### Error Handling
+### Design Principles
 
-The server includes comprehensive error handling:
-- **Authentication errors** - Clear messages for invalid credentials
-- **API errors** - Detailed error responses from Plytix API
-- **Network errors** - Timeout and connection error handling
-- **Validation errors** - Input validation with helpful messages
+This MCP server is intentionally **stateless and lightweight**:
 
-## Contributing
+- **No database** — All queries go directly to Plytix API
+- **No sync/caching layer** — Fresh data on every request
+- **No background jobs** — Request/response only
+- **Ephemeral in-memory cache** — Brief (60s) request deduplication, cleared on restart
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature-name`
-3. Make your changes
-4. Run tests: `npm run test:all`
-5. Commit your changes: `git commit -m 'Add feature'`
-6. Push to the branch: `git push origin feature-name`
-7. Submit a pull request
+For ETL, sync, or persistent caching needs, use a separate tool like [supplyline-sync](https://github.com/Supplyline/supplyline-sync).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT License — see [LICENSE](LICENSE) file for details.
 
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/Supplyline/plytix-mcp/issues)
-- **Documentation**: [Plytix API Docs](https://docs.plytix.com/)
+- **Plytix API**: [Plytix Documentation](https://docs.plytix.com/)
 - **MCP Protocol**: [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -2,7 +2,7 @@
  * Attribute Tools
  *
  * Tools for discovering and listing product attributes.
- * Useful for understanding available fields and building sync logic.
+ * Useful for understanding available fields and building queries.
  */
 
 import { z } from 'zod';
@@ -21,7 +21,7 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
       description:
         'List all available product attributes (system and custom). ' +
         'Returns attribute keys, types, labels, and options for dropdown fields. ' +
-        'Use this to discover what attributes exist for syncing to external systems.',
+        'Use this to discover what attributes exist and their data types.',
       inputSchema: {
         include_options: z
           .boolean()


### PR DESCRIPTION
- Update README to document all 11 MCP tools (was showing only 5)
- Add smart lookup system documentation
- Add inheritance tracking section
- Emphasize stateless design with no database/sync
- Reference supplyline-sync for ETL/caching needs
- Remove "sync logic" references from attribute tools

This MCP provides direct Plytix API access only.
No sync functionality exists to remove.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances documentation and clarifies scope.
> 
> - Expands `README.md` with full list of 11 MCP tools (tables), smart lookup flow, inheritance tracking, environment variables, scripts, architecture, and design principles; streamlines usage (Claude config + standalone) and adds references (Plytix docs, supplyline-sync)
> - Emphasizes read-only, stateless behavior with no sync/caching and rate-limit handling
> - Updates `attributes.ts` tool descriptions to remove "sync" language and focus on building queries/data types (no functional code changes)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd5763ef586a7bfcc9de79f216d864970cf12924. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->