### PR TITLE
feat: Add variants_resync tool to Cloudflare Worker

### DIFF
--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -311,6 +311,27 @@ export class WorkerPlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
+  // Variants (v1 API - write operations)
+  // ─────────────────────────────────────────────────────────────
+
+  async resyncVariants(
+    parentProductId: string,
+    attributeLabels: string[],
+    variantIds: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/products/${encodeURIComponent(parentProductId)}/variants/resync`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          attribute_labels: attributeLabels,
+          variant_ids: variantIds,
+        }),
+      }
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
   // Generic Request (for custom endpoints)
   // ─────────────────────────────────────────────────────────────
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -268,6 +268,32 @@ const TOOLS: ToolDefinition[] = [
       required: ['product_id'],
     },
   },
+  {
+    name: 'variants_resync',
+    description:
+      'Resync variant attributes to inherit values from the parent product. ' +
+      'Restores overwritten attributes on specified variants to use the parent\'s value instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        parent_product_id: {
+          type: 'string',
+          description: 'The parent product ID containing the variants',
+        },
+        attribute_labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of attribute labels to reset (must be attributes at parent level)',
+        },
+        variant_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of variant product IDs to resync (must be variants of the specified parent)',
+        },
+      },
+      required: ['parent_product_id', 'attribute_labels', 'variant_ids'],
+    },
+  },
 ];
 
 // ─────────────────────────────────────────────────────────────
@@ -555,6 +581,32 @@ const toolHandlers: Record<string, ToolHandler> = {
             {
               variants: result.data,
               count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async variants_resync(args, client) {
+    const parentProductId = args.parent_product_id as string;
+    const attributeLabels = args.attribute_labels as string[];
+    const variantIds = args.variant_ids as string[];
+
+    await client.resyncVariants(parentProductId, attributeLabels, variantIds);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              parent_product_id: parentProductId,
+              attributes_reset: attributeLabels,
+              variants_affected: variantIds.length,
             },
             null,
             2


### PR DESCRIPTION
## Summary
- Adds `variants_resync` tool to the Cloudflare Worker for remote MCP access
- Enables Craft Agents and HTTP-based MCP clients to reset variant attributes to parent values
- Adds `resyncVariants()` method to `WorkerPlytixClient`

## Test plan
- [ ] `npm run typecheck:worker` passes
- [ ] `npm run build:worker` succeeds
- [ ] Deploy with `npm run deploy` and test against live Plytix account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds write capability to reset variant attributes via MCP and the Plytix client.
> 
> - New `variants_resync` tool in `worker.ts` with schema: `parent_product_id`, `attribute_labels`, `variant_ids`; handler calls client and returns a success summary
> - New `resyncVariants()` in `worker-client.ts` hitting `POST /api/v1/products/{parentProductId}/variants/resync` with `attribute_labels` and `variant_ids` payload
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b065d8acb77f3d519709667587d5d7e8860136f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->