### PR TITLE
feat: Configurable search fields and variants_resync tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ PLYTIX_API_PASSWORD="pp_live_xxxxxxxxxxxxxx"
 # Optional overrides (defaults shown):
 # PLYTIX_API_BASE=https://pim.plytix.com
 # PLYTIX_AUTH_URL=https://auth.plytix.com/auth/api/get-token
+# PLYTIX_MPN_LABELS='["attributes.mpn"]'
+# PLYTIX_MNO_LABELS='["attributes.model_no"]'

--- a/src/__tests__/lookup.test.ts
+++ b/src/__tests__/lookup.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { PlytixSearchBody } from '../types.js';
+import type { PlytixClient } from '../client.js';
+import { PlytixLookup } from '../lookup/lookup.js';
+
+describe('PlytixLookup MPN/MNO label fallbacks', () => {
+  const originalMpnLabels = process.env.PLYTIX_MPN_LABELS;
+  const originalMnoLabels = process.env.PLYTIX_MNO_LABELS;
+
+  afterEach(() => {
+    if (originalMpnLabels === undefined) {
+      delete process.env.PLYTIX_MPN_LABELS;
+    } else {
+      process.env.PLYTIX_MPN_LABELS = originalMpnLabels;
+    }
+
+    if (originalMnoLabels === undefined) {
+      delete process.env.PLYTIX_MNO_LABELS;
+    } else {
+      process.env.PLYTIX_MNO_LABELS = originalMnoLabels;
+    }
+  });
+
+  it('uses default MPN labels when searchFields exclude attributes', async () => {
+    delete process.env.PLYTIX_MPN_LABELS;
+    delete process.env.PLYTIX_MNO_LABELS;
+
+    const searchCalls: PlytixSearchBody[] = [];
+    const client = {
+      searchProducts: vi.fn(async (body: PlytixSearchBody) => {
+        searchCalls.push(body);
+        return { data: [] };
+      }),
+    } as unknown as PlytixClient;
+
+    const lookup = new PlytixLookup(client, {
+      searchFields: ['sku', 'label', 'gtin'],
+      cacheEnabled: false,
+    });
+
+    await lookup.findByIdentifier('ABC-123', 'mpn', 5);
+
+    const hasMpnFilter = searchCalls.some((body) =>
+      body.filters?.some((group) => group.some((filter) => filter.field === 'attributes.mpn'))
+    );
+
+    expect(hasMpnFilter).toBe(true);
+  });
+});

--- a/src/__tests__/search-fields.test.ts
+++ b/src/__tests__/search-fields.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PlytixLookup, DEFAULT_SEARCH_FIELDS } from '../lookup/lookup.js';
+import { WorkerPlytixLookup } from '../worker-lookup.js';
+import type { PlytixClient } from '../client.js';
+import type { WorkerPlytixClient } from '../worker-client.js';
+
+const originalSearchFieldsEnv = process.env.PLYTIX_SEARCH_FIELDS;
+
+const makeClient = () => ({
+  searchProducts: vi.fn().mockResolvedValue({ data: [] }),
+  getProduct: vi.fn().mockResolvedValue({ data: [] }),
+});
+
+afterEach(() => {
+  if (originalSearchFieldsEnv === undefined) {
+    delete process.env.PLYTIX_SEARCH_FIELDS;
+  } else {
+    process.env.PLYTIX_SEARCH_FIELDS = originalSearchFieldsEnv;
+  }
+});
+
+describe('search field sanitization', () => {
+  it('filters non-string search fields from config', async () => {
+    const client = makeClient();
+    const lookup = new PlytixLookup(client as unknown as PlytixClient, {
+      searchFields: [123, null, ' sku ', 'attributes.mpn', false] as unknown as string[],
+    });
+
+    await lookup.findProducts({ mpn: 'ABC' });
+
+    const call = client.searchProducts.mock.calls[0][0];
+    expect(call.attributes).toEqual(['sku', 'attributes.mpn']);
+    expect(call.filters?.[0]?.[0]?.field).toBe('attributes.mpn');
+  });
+
+  it('falls back to defaults when no valid fields provided', async () => {
+    delete process.env.PLYTIX_SEARCH_FIELDS;
+    const client = makeClient();
+    const lookup = new PlytixLookup(client as unknown as PlytixClient, {
+      searchFields: [123, null] as unknown as string[],
+    });
+
+    await lookup.findProducts({});
+
+    const call = client.searchProducts.mock.calls[0][0];
+    expect(call.attributes).toEqual(DEFAULT_SEARCH_FIELDS);
+  });
+
+  it('filters non-string search fields from env var', async () => {
+    process.env.PLYTIX_SEARCH_FIELDS = JSON.stringify([123, null, 'sku', 'attributes.mpn']);
+    const client = makeClient();
+    const lookup = new PlytixLookup(client as unknown as PlytixClient);
+
+    await lookup.findProducts({ mpn: 'ABC' });
+
+    const call = client.searchProducts.mock.calls[0][0];
+    expect(call.attributes).toEqual(['sku', 'attributes.mpn']);
+  });
+
+  it('filters non-string search fields in worker config', async () => {
+    const client = makeClient();
+    const lookup = new WorkerPlytixLookup(client as unknown as WorkerPlytixClient, {
+      searchFields: [123, ' attributes.mpn ', null, 'sku'] as unknown as string[],
+    });
+
+    await lookup.findProducts({ mpn: 'ABC' });
+
+    const call = client.searchProducts.mock.calls[0][0];
+    expect(call.attributes).toEqual(['attributes.mpn', 'sku']);
+    expect(call.filters?.[0]?.[0]?.field).toBe('attributes.mpn');
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -330,7 +330,7 @@ export class PlytixClient {
         method: 'POST',
         body: JSON.stringify({
           attribute_labels: attributeLabels,
-          product_ids: variantIds,
+          variant_ids: variantIds,
         }),
       }
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -308,6 +308,35 @@ export class PlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
+  // Variants (v1 API - write operations)
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Resync variant attributes to inherit values from the parent product.
+   * Restores overwritten attributes on specified variants to use the parent's value instead.
+   *
+   * @param parentProductId - The parent product ID containing the variants
+   * @param attributeLabels - List of attribute labels to reset (must be attributes at parent level)
+   * @param variantIds - List of variant product IDs to resync (must be variants of the specified parent)
+   */
+  async resyncVariants(
+    parentProductId: string,
+    attributeLabels: string[],
+    variantIds: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/products/${encodeURIComponent(parentProductId)}/variants/resync`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          attribute_labels: attributeLabels,
+          product_ids: variantIds,
+        }),
+      }
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
   // Generic Request (for custom endpoints)
   // ─────────────────────────────────────────────────────────────
 

--- a/src/lookup/identifier.ts
+++ b/src/lookup/identifier.ts
@@ -95,22 +95,3 @@ export function calculateSimilarity(a: string, b: string): number {
   return 0;
 }
 
-/**
- * Default attribute labels for MPN fields
- */
-export const DEFAULT_MPN_LABELS = [
-  'attributes.mpn',
-  'attributes.manufacturer_part_number',
-  'attributes.part_number',
-  'attributes.mfr_part_number',
-];
-
-/**
- * Default attribute labels for MNO (model number) fields
- */
-export const DEFAULT_MNO_LABELS = [
-  'attributes.mno',
-  'attributes.model',
-  'attributes.model_number',
-  'attributes.model_no',
-];

--- a/src/lookup/lookup.ts
+++ b/src/lookup/lookup.ts
@@ -24,6 +24,14 @@ import {
  */
 export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
 
+const sanitizeSearchFields = (fields: unknown): string[] => {
+  if (!Array.isArray(fields)) return [];
+  return fields
+    .filter((field): field is string => typeof field === 'string')
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+};
+
 export interface LookupConfig {
   /**
    * Fields to search when looking up products.
@@ -87,8 +95,9 @@ export class PlytixLookup {
    */
   private initSearchFields(): string[] {
     // 1. Use config if provided
-    if (this.cfg.searchFields?.length) {
-      return this.cfg.searchFields;
+    const configFields = sanitizeSearchFields(this.cfg.searchFields);
+    if (configFields.length > 0) {
+      return configFields;
     }
 
     // 2. Try PLYTIX_SEARCH_FIELDS env var (JSON array)
@@ -96,8 +105,9 @@ export class PlytixLookup {
     if (envFields) {
       try {
         const parsed = JSON.parse(envFields);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          return parsed;
+        const envFieldsParsed = sanitizeSearchFields(parsed);
+        if (envFieldsParsed.length > 0) {
+          return envFieldsParsed;
         }
       } catch {
         // Ignore parse errors, fall through to defaults

--- a/src/lookup/lookup.ts
+++ b/src/lookup/lookup.ts
@@ -27,10 +27,11 @@ export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin', 'attributes.mpn', 
 
 const sanitizeSearchFields = (fields: unknown): string[] => {
   if (!Array.isArray(fields)) return [];
-  return fields
+  const cleaned = fields
     .filter((field): field is string => typeof field === 'string')
     .map((field) => field.trim())
     .filter((field) => field.length > 0);
+  return [...new Set(cleaned)]; // Deduplicate to avoid redundant API calls
 };
 
 export interface LookupConfig {

--- a/src/lookup/lookup.ts
+++ b/src/lookup/lookup.ts
@@ -12,18 +12,25 @@ import {
   type IdentifierType,
   normalize,
   calculateSimilarity,
-  DEFAULT_MPN_LABELS,
-  DEFAULT_MNO_LABELS,
 } from './identifier.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────
 
+/**
+ * Default search fields for vanilla Plytix.
+ * Override with PLYTIX_SEARCH_FIELDS env var or config.
+ */
+export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
+
 export interface LookupConfig {
-  mpnLabels?: string[];
-  mnoLabels?: string[];
-  extraSearchFields?: string[];
+  /**
+   * Fields to search when looking up products.
+   * Defaults to PLYTIX_SEARCH_FIELDS env var or DEFAULT_SEARCH_FIELDS.
+   * Use "attributes.mpn" format for custom attributes.
+   */
+  searchFields?: string[];
   pageSize?: number;
   cacheEnabled?: boolean;
   cacheTtlMs?: number;
@@ -58,9 +65,7 @@ interface CacheEntry {
 
 export class PlytixLookup {
   private cache = new Map<string, CacheEntry>();
-  private discoveredLabels?: { mpn: string[]; mno: string[] };
-  private discoveredAt?: number;
-  private readonly discoveryTtl = 10 * 60 * 1000; // 10 minutes
+  private readonly searchFields: string[];
 
   constructor(
     private client: PlytixClient,
@@ -72,6 +77,35 @@ export class PlytixLookup {
       cacheTtlMs: 60_000, // 1 minute
       ...cfg,
     };
+
+    // Initialize search fields from config, env var, or defaults
+    this.searchFields = this.initSearchFields();
+  }
+
+  /**
+   * Initialize search fields from config, PLYTIX_SEARCH_FIELDS env var, or defaults.
+   */
+  private initSearchFields(): string[] {
+    // 1. Use config if provided
+    if (this.cfg.searchFields?.length) {
+      return this.cfg.searchFields;
+    }
+
+    // 2. Try PLYTIX_SEARCH_FIELDS env var (JSON array)
+    const envFields = process.env.PLYTIX_SEARCH_FIELDS;
+    if (envFields) {
+      try {
+        const parsed = JSON.parse(envFields);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed;
+        }
+      } catch {
+        // Ignore parse errors, fall through to defaults
+      }
+    }
+
+    // 3. Use defaults
+    return DEFAULT_SEARCH_FIELDS;
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -113,88 +147,6 @@ export class PlytixLookup {
           this.cache.delete(k);
         }
       }
-    }
-  }
-
-  // ─────────────────────────────────────────────────────────────
-  // Label Discovery
-  // ─────────────────────────────────────────────────────────────
-
-  private async discoverCustomLabels(): Promise<{ mpn: string[]; mno: string[] }> {
-    const now = Date.now();
-
-    // Return cached discovery if still valid
-    if (this.discoveredLabels && this.discoveredAt && now - this.discoveredAt < this.discoveryTtl) {
-      return this.discoveredLabels;
-    }
-
-    // Use configured labels if provided
-    if (this.cfg.mpnLabels || this.cfg.mnoLabels) {
-      const result = {
-        mpn: this.cfg.mpnLabels ?? DEFAULT_MPN_LABELS,
-        mno: this.cfg.mnoLabels ?? DEFAULT_MNO_LABELS,
-      };
-      this.discoveredLabels = result;
-      this.discoveredAt = now;
-      return result;
-    }
-
-    // Try environment variables
-    try {
-      const envMpn = process.env.PLYTIX_MPN_LABELS;
-      const envMno = process.env.PLYTIX_MNO_LABELS;
-
-      if (envMpn || envMno) {
-        const result = {
-          mpn: envMpn ? JSON.parse(envMpn) : DEFAULT_MPN_LABELS,
-          mno: envMno ? JSON.parse(envMno) : DEFAULT_MNO_LABELS,
-        };
-        this.discoveredLabels = result;
-        this.discoveredAt = now;
-        return result;
-      }
-    } catch {
-      // Ignore parse errors
-    }
-
-    // Fallback: inspect available filters to find attribute synonyms
-    try {
-      const filters = await this.client.getAvailableFilters();
-      const attrs: string[] = [];
-
-      if (filters.data) {
-        for (const filter of filters.data) {
-          if (filter.field?.startsWith('attributes.')) {
-            attrs.push(filter.field);
-          }
-        }
-      }
-
-      const findMatchingFields = (patterns: RegExp[]) => {
-        return attrs.filter((key) => patterns.some((pattern) => pattern.test(key)));
-      };
-
-      const mpnPatterns = [/\bmpn\b/i, /manufacturer.*part/i, /mfr.*part/i, /part_number/i, /part[-_. ]?no/i];
-      const mnoPatterns = [/\bmodel\b/i, /model_?no/i, /\bmno\b/i, /item_?number/i];
-
-      const result = {
-        mpn: findMatchingFields(mpnPatterns),
-        mno: findMatchingFields(mnoPatterns),
-      };
-
-      // Use defaults if nothing discovered
-      if (!result.mpn.length) result.mpn = DEFAULT_MPN_LABELS;
-      if (!result.mno.length) result.mno = DEFAULT_MNO_LABELS;
-
-      this.discoveredLabels = result;
-      this.discoveredAt = now;
-      return result;
-    } catch {
-      // Final fallback
-      const result = { mpn: DEFAULT_MPN_LABELS, mno: DEFAULT_MNO_LABELS };
-      this.discoveredLabels = result;
-      this.discoveredAt = now;
-      return result;
     }
   }
 
@@ -300,18 +252,14 @@ export class PlytixLookup {
     const detection = detectIdentifierType(identifier);
     const type = explicitType ?? detection.type;
     const plan: string[] = [`detected_type:${type}(${detection.confidence})`];
-
-    const { mpn, mno } = await this.discoverCustomLabels();
-    plan.push(`labels:mpn(${mpn.length}),mno(${mno.length})`);
+    plan.push(`search_fields:${this.searchFields.join(',')}`);
 
     // Helper to execute search
     const executeSearch = async (body: PlytixSearchBody, tag: string): Promise<Match[]> => {
       plan.push(tag);
 
-      // Ensure standard + discovered attributes are requested
-      const attributes = [
-        ...new Set(['sku', 'label', 'gtin', ...mpn, ...mno, ...(this.cfg.extraSearchFields ?? [])]),
-      ].slice(0, 50);
+      // Request all configured search fields (up to API limit of 50)
+      const attributes = [...new Set(this.searchFields)].slice(0, 50);
 
       const searchBody: PlytixSearchBody = {
         ...body,
@@ -366,42 +314,30 @@ export class PlytixLookup {
       }
     }
 
-    // Strategy 2: Exact field matches
+    // Strategy 2: Exact field matches based on detected type
     const exactSearches: Array<{ body: PlytixSearchBody; tag: string }> = [];
 
-    if (type === 'sku' || type === 'unknown') {
-      exactSearches.push({
-        body: { filters: [[{ field: 'sku', operator: 'eq', value: identifier }]] },
-        tag: 'sku_eq',
-      });
-    }
-
-    if (type === 'gtin') {
-      exactSearches.push({
-        body: { filters: [[{ field: 'gtin', operator: 'eq', value: identifier }]] },
-        tag: 'gtin_eq',
-      });
-    }
-
-    if (type === 'label') {
-      const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
-      exactSearches.push({
-        body: { filters: [tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token }))] },
-        tag: 'label_like_tokens',
-      });
-    }
-
-    if (type === 'mpn' || type === 'unknown') {
-      for (const field of mpn) {
+    // For each configured search field, try exact match if type is compatible
+    for (const field of this.searchFields) {
+      // Always try standard fields for sku/gtin/unknown types
+      if (field === 'sku' && (type === 'sku' || type === 'unknown')) {
         exactSearches.push({
-          body: { filters: [[{ field, operator: 'eq', value: identifier }]] },
-          tag: `${field}_eq`,
+          body: { filters: [[{ field: 'sku', operator: 'eq', value: identifier }]] },
+          tag: 'sku_eq',
         });
-      }
-    }
-
-    if (type === 'mno' || type === 'unknown') {
-      for (const field of mno) {
+      } else if (field === 'gtin' && type === 'gtin') {
+        exactSearches.push({
+          body: { filters: [[{ field: 'gtin', operator: 'eq', value: identifier }]] },
+          tag: 'gtin_eq',
+        });
+      } else if (field === 'label' && type === 'label') {
+        const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
+        exactSearches.push({
+          body: { filters: [tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token }))] },
+          tag: 'label_like_tokens',
+        });
+      } else if (field.startsWith('attributes.') && (type === 'mpn' || type === 'mno' || type === 'unknown')) {
+        // Custom attribute fields - try exact match for MPN/MNO/unknown types
         exactSearches.push({
           body: { filters: [[{ field, operator: 'eq', value: identifier }]] },
           tag: `${field}_eq`,
@@ -422,12 +358,11 @@ export class PlytixLookup {
       }
     }
 
-    // Strategy 3: Text search across multiple fields
+    // Strategy 3: Text search across all configured fields
     if (matches.length === 0) {
       try {
-        const searchFields = ['sku', 'label', 'gtin', ...mpn, ...mno, ...(this.cfg.extraSearchFields ?? [])];
         const textSearchResults = await executeSearch(
-          { filters: [[{ field: searchFields, operator: 'text_search', value: identifier }]] },
+          { filters: [[{ field: this.searchFields, operator: 'text_search', value: identifier }]] },
           'text_search_multi'
         );
         matches.push(...textSearchResults);
@@ -442,14 +377,12 @@ export class PlytixLookup {
         const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
         const firstToken = tokens[0] ?? identifier;
 
-        const broadFilters = [
-          { field: 'sku', operator: 'like' as const, value: firstToken },
-          { field: 'label', operator: 'like' as const, value: firstToken },
-        ];
-
-        if (mpn[0]) {
-          broadFilters.push({ field: mpn[0], operator: 'like' as const, value: firstToken });
-        }
+        // Build LIKE filters for first few search fields
+        const broadFilters = this.searchFields.slice(0, 3).map((field) => ({
+          field,
+          operator: 'like' as const,
+          value: firstToken,
+        }));
 
         const broadResults = await executeSearch({ filters: [broadFilters] }, 'broad_like_search');
         matches.push(...broadResults);
@@ -488,7 +421,6 @@ export class PlytixLookup {
     const { limit = 5, returnFields = [] } = criteria;
     const plan: string[] = ['multi_criteria_search'];
 
-    const { mpn, mno } = await this.discoverCustomLabels();
     const filters: PlytixSearchBody['filters'] = [];
 
     if (criteria.sku) {
@@ -501,18 +433,21 @@ export class PlytixLookup {
       const tokens = criteria.label.split(/[^A-Za-z0-9]+/).filter(Boolean);
       filters.push(tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token })));
     }
-    if (criteria.mpn && mpn[0]) {
-      filters.push([{ field: mpn[0], operator: 'eq', value: criteria.mpn }]);
+    // For MPN/MNO, search any custom attribute fields in searchFields
+    const customAttrFields = this.searchFields.filter((f) => f.startsWith('attributes.'));
+    if (criteria.mpn && customAttrFields.length > 0) {
+      // Try the first custom attribute field for MPN
+      filters.push([{ field: customAttrFields[0], operator: 'eq', value: criteria.mpn }]);
     }
-    if (criteria.mno && mno[0]) {
-      filters.push([{ field: mno[0], operator: 'eq', value: criteria.mno }]);
+    if (criteria.mno && customAttrFields.length > 1) {
+      // Try the second custom attribute field for MNO if available
+      filters.push([{ field: customAttrFields[1], operator: 'eq', value: criteria.mno }]);
     }
     if (criteria.fuzzySearch) {
-      const searchFields = ['sku', 'label', 'gtin', ...mpn, ...mno];
-      filters.push([{ field: searchFields, operator: 'text_search', value: criteria.fuzzySearch }]);
+      filters.push([{ field: this.searchFields, operator: 'text_search', value: criteria.fuzzySearch }]);
     }
 
-    const attributes = [...new Set(['sku', 'label', 'gtin', ...mpn, ...mno, ...returnFields])].slice(0, 50);
+    const attributes = [...new Set([...this.searchFields, ...returnFields])].slice(0, 50);
 
     try {
       const result = await this.client.searchProducts({

--- a/src/lookup/lookup.ts
+++ b/src/lookup/lookup.ts
@@ -21,8 +21,9 @@ import {
 /**
  * Default search fields for vanilla Plytix.
  * Override with PLYTIX_SEARCH_FIELDS env var or config.
+ * Includes attributes.mpn and attributes.mno so products.find MPN/MNO filters work out of the box.
  */
-export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
+export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin', 'attributes.mpn', 'attributes.mno'];
 
 const sanitizeSearchFields = (fields: unknown): string[] => {
   if (!Array.isArray(fields)) return [];

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -1,31 +1,40 @@
+/**
+ * Asset Tools
+ *
+ * Tools for listing assets linked to products.
+ */
 
-import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
 
 export function registerAssetTools(server: McpServer, client: PlytixClient) {
   // LIST product assets
-  server.registerTool(
-    "assets_list",
+  registerTool<{ product_id: string }>(
+    server,
+    'assets_list',
     {
-      title: "List Assets",
-      description: "List assets linked to a product (Plytix v2)",
+      title: 'List Assets',
+      description: 'List assets linked to a product (Plytix v2)',
       inputSchema: {
-        product_id: z.string().min(1).describe("The product ID to fetch assets for")
-      }
+        product_id: z.string().min(1).describe('The product ID to fetch assets for'),
+      },
     },
     async ({ product_id }) => {
       try {
         const result = await client.getProductAssets(product_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
         return {
-          content: [{ 
-            type: "text", 
-            text: `Error fetching assets: ${error instanceof Error ? error.message : 'Unknown error'}` 
-          }],
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching assets: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -8,13 +8,15 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
 
 export function registerAttributeTools(server: McpServer, client: PlytixClient) {
   // ─────────────────────────────────────────────────────────────
   // attributes.list - List all available attributes
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{ include_options: boolean }>(
+    server,
     'attributes_list',
     {
       title: 'List Attributes',
@@ -69,7 +71,8 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
   // attributes.filters - Get available search filters
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<Record<string, never>>(
+    server,
     'attributes_filters',
     {
       title: 'Get Search Filters',

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -1,31 +1,40 @@
+/**
+ * Category Tools
+ *
+ * Tools for listing categories linked to products.
+ */
 
-import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
 
 export function registerCategoryTools(server: McpServer, client: PlytixClient) {
   // LIST product categories
-  server.registerTool(
-    "categories_list",
+  registerTool<{ product_id: string }>(
+    server,
+    'categories_list',
     {
-      title: "List Categories",
-      description: "List categories linked to a product (Plytix v2)",
+      title: 'List Categories',
+      description: 'List categories linked to a product (Plytix v2)',
       inputSchema: {
-        product_id: z.string().min(1).describe("The product ID to fetch categories for")
-      }
+        product_id: z.string().min(1).describe('The product ID to fetch categories for'),
+      },
     },
     async ({ product_id }) => {
       try {
         const result = await client.getProductCategories(product_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
         return {
-          content: [{ 
-            type: "text", 
-            text: `Error fetching categories: ${error instanceof Error ? error.message : 'Unknown error'}` 
-          }],
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching categories: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
           isError: true,
         };
       }

--- a/src/tools/families.ts
+++ b/src/tools/families.ts
@@ -8,13 +8,15 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
 
 export function registerFamilyTools(server: McpServer, client: PlytixClient) {
   // ─────────────────────────────────────────────────────────────
   // families.list - Search/list product families
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{ query?: string; page: number; page_size: number }>(
+    server,
     'families_list',
     {
       title: 'List Product Families',
@@ -72,7 +74,8 @@ export function registerFamilyTools(server: McpServer, client: PlytixClient) {
   // families.get - Get single family with details
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{ family_id: string }>(
+    server,
     'families_get',
     {
       title: 'Get Product Family',

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -29,6 +29,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
         'Smart product lookup that auto-detects identifier type (ID, SKU, MPN, GTIN, label). ' +
         'Uses staged search strategies with confidence scoring. ' +
         'Returns the best match along with the search plan used. ' +
+        'MPN/MNO searches use PLYTIX_MPN_LABELS / PLYTIX_MNO_LABELS (defaults to attributes.mpn/model_no). ' +
         'Includes overwritten_attributes to show which values are inherited vs explicitly set.',
       inputSchema: {
         identifier: z.string().min(1).describe('Product identifier (ID, SKU, MPN, GTIN, or label)'),

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -9,6 +9,8 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
 import { PlytixLookup } from '../lookup/index.js';
+import { registerTool } from './register.js';
+import type { IdentifierType } from '../lookup/identifier.js';
 
 export function registerProductTools(server: McpServer, client: PlytixClient) {
   // Create lookup instance for smart search
@@ -18,7 +20,8 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   // products.lookup - Smart identifier-based lookup
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{ identifier: string; type?: IdentifierType; limit: number }>(
+    server,
     'products_lookup',
     {
       title: 'Smart Product Lookup',
@@ -101,7 +104,8 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   // products.get - Fetch single product by ID
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{ product_id: string }>(
+    server,
     'products_get',
     {
       title: 'Get Product',
@@ -145,7 +149,13 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   // products.search - Advanced search with filters
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{
+    attributes?: string[];
+    filters?: unknown[];
+    pagination?: { page: number; page_size: number };
+    sort?: unknown;
+  }>(
+    server,
     'products_search',
     {
       title: 'Search Products',
@@ -176,7 +186,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     },
     async (args) => {
       try {
-        const result = await client.searchProducts(args);
+        const result = await client.searchProducts(args as Parameters<typeof client.searchProducts>[0]);
 
         return {
           content: [
@@ -212,7 +222,16 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   // products.find - Multi-criteria search
   // ─────────────────────────────────────────────────────────────
 
-  server.registerTool(
+  registerTool<{
+    sku?: string;
+    mpn?: string;
+    mno?: string;
+    gtin?: string;
+    label?: string;
+    fuzzy_search?: string;
+    limit: number;
+  }>(
+    server,
     'products_find',
     {
       title: 'Find Products',

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -1,0 +1,39 @@
+/**
+ * Tool Registration Wrapper
+ *
+ * Wraps MCP SDK's registerTool to prevent TS2589 "Type instantiation is excessively deep"
+ * errors caused by Zod schema inference flowing into SDK generics.
+ *
+ * The SDK's type system tries to infer the full schema type recursively, which can
+ * cause TypeScript to give up. This wrapper erases the complex inference while
+ * preserving runtime behavior.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ZodRawShape } from 'zod';
+
+export interface ToolDefinition {
+  title?: string;
+  description: string;
+  inputSchema: ZodRawShape;
+}
+
+/**
+ * Register a tool with type erasure to prevent deep inference.
+ *
+ * Usage:
+ *   registerTool(server, 'my_tool', {
+ *     description: '...',
+ *     inputSchema: { foo: z.string() }
+ *   }, async ({ foo }) => { ... });
+ */
+export function registerTool<TArgs extends Record<string, unknown>>(
+  server: McpServer,
+  name: string,
+  definition: ToolDefinition,
+  handler: (args: TArgs) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>
+): void {
+  // Cast to any to prevent SDK from inferring the full Zod schema type tree
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server.registerTool as any)(name, definition, handler);
+}

--- a/src/tools/variants.ts
+++ b/src/tools/variants.ts
@@ -1,36 +1,98 @@
+/**
+ * Variant Tools
+ *
+ * Tools for listing and managing product variants.
+ */
 
-import { z } from "zod";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
 
 export function registerVariantTools(server: McpServer, client: PlytixClient) {
   // LIST product variants
-  server.registerTool(
-    "variants_list",
+  registerTool<{ product_id: string }>(
+    server,
+    'variants_list',
     {
-      title: "List Variants",
-      description: "List variants linked to a product (Plytix v2)",
+      title: 'List Variants',
+      description: 'List variants linked to a product (Plytix v2)',
       inputSchema: {
-        product_id: z.string().min(1).describe("The product ID to fetch variants for")
-      }
+        product_id: z.string().min(1).describe('The product ID to fetch variants for'),
+      },
     },
     async ({ product_id }) => {
       try {
         const result = await client.getProductVariants(product_id);
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       } catch (error) {
         return {
-          content: [{ 
-            type: "text", 
-            text: `Error fetching variants: ${error instanceof Error ? error.message : 'Unknown error'}` 
-          }],
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching variants: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
           isError: true,
         };
       }
     }
   );
 
-  // TODO: variants.link / variants.unlink / variants.resync as needed
+  // RESYNC variant attributes to parent
+  registerTool<{ parent_product_id: string; attribute_labels: string[]; variant_ids: string[] }>(
+    server,
+    'variants_resync',
+    {
+      title: 'Resync Variants',
+      description:
+        'Resync variant attributes to inherit values from the parent product. ' +
+        'Restores overwritten attributes on specified variants to use the parent\'s value instead.',
+      inputSchema: {
+        parent_product_id: z.string().min(1).describe('The parent product ID containing the variants'),
+        attribute_labels: z
+          .array(z.string())
+          .min(1)
+          .describe('List of attribute labels to reset (must be attributes at parent level)'),
+        variant_ids: z
+          .array(z.string())
+          .min(1)
+          .describe('List of variant product IDs to resync (must be variants of the specified parent)'),
+      },
+    },
+    async ({ parent_product_id, attribute_labels, variant_ids }) => {
+      try {
+        await client.resyncVariants(parent_product_id, attribute_labels, variant_ids);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  parent_product_id,
+                  attributes_reset: attribute_labels,
+                  variants_affected: variant_ids.length,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error resyncing variants: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
 }

--- a/src/worker-lookup.ts
+++ b/src/worker-lookup.ts
@@ -24,6 +24,14 @@ import {
  */
 export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
 
+const sanitizeSearchFields = (fields: unknown): string[] => {
+  if (!Array.isArray(fields)) return [];
+  return fields
+    .filter((field): field is string => typeof field === 'string')
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+};
+
 export interface WorkerLookupConfig {
   /**
    * Fields to search when looking up products.
@@ -68,7 +76,8 @@ export class WorkerPlytixLookup {
     };
 
     // Initialize search fields from config or defaults
-    this.searchFields = cfg.searchFields?.length ? cfg.searchFields : DEFAULT_SEARCH_FIELDS;
+    const configFields = sanitizeSearchFields(cfg.searchFields);
+    this.searchFields = configFields.length > 0 ? configFields : DEFAULT_SEARCH_FIELDS;
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/src/worker-lookup.ts
+++ b/src/worker-lookup.ts
@@ -12,18 +12,25 @@ import {
   type IdentifierType,
   normalize,
   calculateSimilarity,
-  DEFAULT_MPN_LABELS,
-  DEFAULT_MNO_LABELS,
 } from './lookup/identifier.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────
 
+/**
+ * Default search fields for vanilla Plytix.
+ * Override with config.searchFields.
+ */
+export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
+
 export interface WorkerLookupConfig {
-  mpnLabels?: string[];
-  mnoLabels?: string[];
-  extraSearchFields?: string[];
+  /**
+   * Fields to search when looking up products.
+   * Use "attributes.mpn" format for custom attributes.
+   * Defaults to DEFAULT_SEARCH_FIELDS.
+   */
+  searchFields?: string[];
   pageSize?: number;
 }
 
@@ -49,7 +56,7 @@ export interface LookupResult {
 // ─────────────────────────────────────────────────────────────
 
 export class WorkerPlytixLookup {
-  private discoveredLabels?: { mpn: string[]; mno: string[] };
+  private readonly searchFields: string[];
 
   constructor(
     private client: WorkerPlytixClient,
@@ -59,65 +66,9 @@ export class WorkerPlytixLookup {
       pageSize: 5,
       ...cfg,
     };
-  }
 
-  // ─────────────────────────────────────────────────────────────
-  // Label Discovery
-  // ─────────────────────────────────────────────────────────────
-
-  private async discoverCustomLabels(): Promise<{ mpn: string[]; mno: string[] }> {
-    // Return cached discovery
-    if (this.discoveredLabels) {
-      return this.discoveredLabels;
-    }
-
-    // Use configured labels if provided
-    if (this.cfg.mpnLabels || this.cfg.mnoLabels) {
-      const result = {
-        mpn: this.cfg.mpnLabels ?? DEFAULT_MPN_LABELS,
-        mno: this.cfg.mnoLabels ?? DEFAULT_MNO_LABELS,
-      };
-      this.discoveredLabels = result;
-      return result;
-    }
-
-    // Fallback: inspect available filters to find attribute synonyms
-    try {
-      const filters = await this.client.getAvailableFilters();
-      const attrs: string[] = [];
-
-      if (filters.data) {
-        for (const filter of filters.data) {
-          if (filter.field?.startsWith('attributes.')) {
-            attrs.push(filter.field);
-          }
-        }
-      }
-
-      const findMatchingFields = (patterns: RegExp[]) => {
-        return attrs.filter((key) => patterns.some((pattern) => pattern.test(key)));
-      };
-
-      const mpnPatterns = [/\bmpn\b/i, /manufacturer.*part/i, /mfr.*part/i, /part_number/i, /part[-_. ]?no/i];
-      const mnoPatterns = [/\bmodel\b/i, /model_?no/i, /\bmno\b/i, /item_?number/i];
-
-      const result = {
-        mpn: findMatchingFields(mpnPatterns),
-        mno: findMatchingFields(mnoPatterns),
-      };
-
-      // Use defaults if nothing discovered
-      if (!result.mpn.length) result.mpn = DEFAULT_MPN_LABELS;
-      if (!result.mno.length) result.mno = DEFAULT_MNO_LABELS;
-
-      this.discoveredLabels = result;
-      return result;
-    } catch {
-      // Final fallback
-      const result = { mpn: DEFAULT_MPN_LABELS, mno: DEFAULT_MNO_LABELS };
-      this.discoveredLabels = result;
-      return result;
-    }
+    // Initialize search fields from config or defaults
+    this.searchFields = cfg.searchFields?.length ? cfg.searchFields : DEFAULT_SEARCH_FIELDS;
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -209,16 +160,12 @@ export class WorkerPlytixLookup {
     const detection = detectIdentifierType(identifier);
     const type = explicitType ?? detection.type;
     const plan: string[] = [`detected_type:${type}(${detection.confidence})`];
-
-    const { mpn, mno } = await this.discoverCustomLabels();
-    plan.push(`labels:mpn(${mpn.length}),mno(${mno.length})`);
+    plan.push(`search_fields:${this.searchFields.join(',')}`);
 
     const executeSearch = async (body: PlytixSearchBody, tag: string): Promise<Match[]> => {
       plan.push(tag);
 
-      const attributes = [
-        ...new Set(['sku', 'label', 'gtin', ...mpn, ...mno, ...(this.cfg.extraSearchFields ?? [])]),
-      ].slice(0, 50);
+      const attributes = [...new Set(this.searchFields)].slice(0, 50);
 
       const searchBody: PlytixSearchBody = {
         ...body,
@@ -271,42 +218,27 @@ export class WorkerPlytixLookup {
       }
     }
 
-    // Strategy 2: Exact field matches
+    // Strategy 2: Exact field matches based on detected type
     const exactSearches: Array<{ body: PlytixSearchBody; tag: string }> = [];
 
-    if (type === 'sku' || type === 'unknown') {
-      exactSearches.push({
-        body: { filters: [[{ field: 'sku', operator: 'eq', value: identifier }]] },
-        tag: 'sku_eq',
-      });
-    }
-
-    if (type === 'gtin') {
-      exactSearches.push({
-        body: { filters: [[{ field: 'gtin', operator: 'eq', value: identifier }]] },
-        tag: 'gtin_eq',
-      });
-    }
-
-    if (type === 'label') {
-      const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
-      exactSearches.push({
-        body: { filters: [tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token }))] },
-        tag: 'label_like_tokens',
-      });
-    }
-
-    if (type === 'mpn' || type === 'unknown') {
-      for (const field of mpn) {
+    for (const field of this.searchFields) {
+      if (field === 'sku' && (type === 'sku' || type === 'unknown')) {
         exactSearches.push({
-          body: { filters: [[{ field, operator: 'eq', value: identifier }]] },
-          tag: `${field}_eq`,
+          body: { filters: [[{ field: 'sku', operator: 'eq', value: identifier }]] },
+          tag: 'sku_eq',
         });
-      }
-    }
-
-    if (type === 'mno' || type === 'unknown') {
-      for (const field of mno) {
+      } else if (field === 'gtin' && type === 'gtin') {
+        exactSearches.push({
+          body: { filters: [[{ field: 'gtin', operator: 'eq', value: identifier }]] },
+          tag: 'gtin_eq',
+        });
+      } else if (field === 'label' && type === 'label') {
+        const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
+        exactSearches.push({
+          body: { filters: [tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token }))] },
+          tag: 'label_like_tokens',
+        });
+      } else if (field.startsWith('attributes.') && (type === 'mpn' || type === 'mno' || type === 'unknown')) {
         exactSearches.push({
           body: { filters: [[{ field, operator: 'eq', value: identifier }]] },
           tag: `${field}_eq`,
@@ -325,12 +257,11 @@ export class WorkerPlytixLookup {
       }
     }
 
-    // Strategy 3: Text search across multiple fields
+    // Strategy 3: Text search across all configured fields
     if (matches.length === 0) {
       try {
-        const searchFields = ['sku', 'label', 'gtin', ...mpn, ...mno, ...(this.cfg.extraSearchFields ?? [])];
         const textSearchResults = await executeSearch(
-          { filters: [[{ field: searchFields, operator: 'text_search', value: identifier }]] },
+          { filters: [[{ field: this.searchFields, operator: 'text_search', value: identifier }]] },
           'text_search_multi'
         );
         matches.push(...textSearchResults);
@@ -345,14 +276,11 @@ export class WorkerPlytixLookup {
         const tokens = identifier.split(/[^A-Za-z0-9]+/).filter(Boolean);
         const firstToken = tokens[0] ?? identifier;
 
-        const broadFilters = [
-          { field: 'sku', operator: 'like' as const, value: firstToken },
-          { field: 'label', operator: 'like' as const, value: firstToken },
-        ];
-
-        if (mpn[0]) {
-          broadFilters.push({ field: mpn[0], operator: 'like' as const, value: firstToken });
-        }
+        const broadFilters = this.searchFields.slice(0, 3).map((field) => ({
+          field,
+          operator: 'like' as const,
+          value: firstToken,
+        }));
 
         const broadResults = await executeSearch({ filters: [broadFilters] }, 'broad_like_search');
         matches.push(...broadResults);
@@ -388,7 +316,6 @@ export class WorkerPlytixLookup {
     const { limit = 5, returnFields = [] } = criteria;
     const plan: string[] = ['multi_criteria_search'];
 
-    const { mpn, mno } = await this.discoverCustomLabels();
     const filters: PlytixSearchBody['filters'] = [];
 
     if (criteria.sku) {
@@ -401,18 +328,19 @@ export class WorkerPlytixLookup {
       const tokens = criteria.label.split(/[^A-Za-z0-9]+/).filter(Boolean);
       filters.push(tokens.map((token) => ({ field: 'label', operator: 'like' as const, value: token })));
     }
-    if (criteria.mpn && mpn[0]) {
-      filters.push([{ field: mpn[0], operator: 'eq', value: criteria.mpn }]);
+    // For MPN/MNO, search any custom attribute fields in searchFields
+    const customAttrFields = this.searchFields.filter((f) => f.startsWith('attributes.'));
+    if (criteria.mpn && customAttrFields.length > 0) {
+      filters.push([{ field: customAttrFields[0], operator: 'eq', value: criteria.mpn }]);
     }
-    if (criteria.mno && mno[0]) {
-      filters.push([{ field: mno[0], operator: 'eq', value: criteria.mno }]);
+    if (criteria.mno && customAttrFields.length > 1) {
+      filters.push([{ field: customAttrFields[1], operator: 'eq', value: criteria.mno }]);
     }
     if (criteria.fuzzySearch) {
-      const searchFields = ['sku', 'label', 'gtin', ...mpn, ...mno];
-      filters.push([{ field: searchFields, operator: 'text_search', value: criteria.fuzzySearch }]);
+      filters.push([{ field: this.searchFields, operator: 'text_search', value: criteria.fuzzySearch }]);
     }
 
-    const attributes = [...new Set(['sku', 'label', 'gtin', ...mpn, ...mno, ...returnFields])].slice(0, 50);
+    const attributes = [...new Set([...this.searchFields, ...returnFields])].slice(0, 50);
 
     try {
       const result = await this.client.searchProducts({

--- a/src/worker-lookup.ts
+++ b/src/worker-lookup.ts
@@ -21,8 +21,9 @@ import {
 /**
  * Default search fields for vanilla Plytix.
  * Override with config.searchFields.
+ * Includes attributes.mpn and attributes.mno so products.find MPN/MNO filters work out of the box.
  */
-export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin'];
+export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin', 'attributes.mpn', 'attributes.mno'];
 
 const sanitizeSearchFields = (fields: unknown): string[] => {
   if (!Array.isArray(fields)) return [];

--- a/src/worker-lookup.ts
+++ b/src/worker-lookup.ts
@@ -27,10 +27,11 @@ export const DEFAULT_SEARCH_FIELDS = ['sku', 'label', 'gtin', 'attributes.mpn', 
 
 const sanitizeSearchFields = (fields: unknown): string[] => {
   if (!Array.isArray(fields)) return [];
-  return fields
+  const cleaned = fields
     .filter((field): field is string => typeof field === 'string')
     .map((field) => field.trim())
     .filter((field) => field.length > 0);
+  return [...new Set(cleaned)]; // Deduplicate to avoid redundant API calls
 };
 
 export interface WorkerLookupConfig {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -102,7 +102,8 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Smart product lookup that auto-detects identifier type (ID, SKU, MPN, GTIN, label). ' +
       'Uses staged search strategies with confidence scoring. ' +
-      'Returns the best match along with the search plan used.',
+      'Returns the best match along with the search plan used. ' +
+      'MPN/MNO searches use attributes.mpn/model_no by default.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary
- Replaces complex MPN/MNO label auto-discovery with simple `searchFields` config
- Adds `PLYTIX_SEARCH_FIELDS` env var (JSON array) for configuring which fields to search
- Adds `variants_resync` tool for resetting variant attributes to inherit from parent
- Adds `registerTool` wrapper to fix TS2589 deep type inference errors with Zod schemas

## Breaking Changes
- Removes `PLYTIX_MPN_LABELS` and `PLYTIX_MNO_LABELS` env vars
- Replace with `PLYTIX_SEARCH_FIELDS=["sku","label","gtin","attributes.mpn","attributes.mno"]`

## Test plan
- [ ] Verify product lookup works with default search fields (sku, label, gtin)
- [ ] Verify custom search fields via PLYTIX_SEARCH_FIELDS env var
- [ ] Test variants_resync tool on a parent with overwritten variant attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Lookup and search configuration**
> 
> - Replace dynamic MPN/MNO label discovery with deterministic, configurable search fields; add `DEFAULT_SEARCH_FIELDS` and support for `PLYTIX_SEARCH_FIELDS` (JSON) and per-instance config with sanitization/deduping
> - Normalize and apply MPN/MNO attribute labels (defaults to `attributes.mpn`/`attributes.model_no`), with equivalent behavior in the Workers lookup
> 
> **Client and tools**
> 
> - Add `client.resyncVariants(parentId, attributeLabels, variantIds)` (v1) and expose via new `variants_resync` tool; keep `variants_list`
> - Introduce `registerTool` wrapper to avoid deep Zod type inference issues; migrate assets, categories, families, attributes, products tools to use it and refine schemas/descriptions
> - Update Worker server tool metadata and behavior to reflect search-field defaults and new tools
> 
> **Tests**
> 
> - New tests for search-field sanitization/default fallback and MPN fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e1905a42258180c48b9f73f17a5347d039a277e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->