### PR TITLE
feat: Add write tools for products and categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ src/
 
 ## Available MCP Tools
 
+### Read Operations
+
 | Tool | Description |
 |------|-------------|
 | `products.lookup` | Smart lookup by any identifier (auto-detects type) |
@@ -57,6 +59,17 @@ src/
 | `assets.list` | List assets linked to a product |
 | `categories.list` | List categories linked to a product |
 | `variants.list` | List variants for a product |
+
+### Write Operations
+
+| Tool | Description |
+|------|-------------|
+| `products.create` | Create a new product (SKU required) |
+| `products.update` | Update product attributes (PATCH - partial update) |
+| `products.assign_family` | Assign/unassign family (⚠️ may cause data loss) |
+| `categories.link` | Link existing category to product |
+| `categories.unlink` | Unlink category from product |
+| `variants.resync` | Restore variant attributes to inherit from parent |
 
 ## Smart Lookup System
 
@@ -147,9 +160,14 @@ Related fields:
 
 ## Session Notes
 
-_Last updated: 2025-01-16_
+_Last updated: 2025-01-22_
 
-### Recent Changes (v0.2.0)
+### Recent Changes
+- Added write tools: `products.create`, `products.update`, `products.assign_family`
+- Added category tools: `categories.link`, `categories.unlink`
+- Client methods for all write operations
+
+### v0.2.0 (2025-01-16)
 - Ported smart lookup system from archived codebase
 - Added families tools (list, get)
 - Added attributes tools (list, filters)

--- a/src/client.ts
+++ b/src/client.ts
@@ -308,6 +308,93 @@ export class PlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
+  // Products - Write Operations (v2 API)
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Create a new product. Only `sku` is mandatory.
+   * Cannot create new attributes, categories, or assets - must link existing ones.
+   */
+  async createProduct(data: {
+    sku: string;
+    label?: string;
+    status?: string;
+    attributes?: Record<string, unknown>;
+    categories?: Array<{ id: string }>;
+    assets?: Array<{ id: string }>;
+  }): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>('/api/v2/products', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  /**
+   * Update a product's attributes. Partial update - only specified fields are changed.
+   * Set an attribute to null to clear it.
+   */
+  async updateProduct(
+    productId: string,
+    data: {
+      label?: string;
+      status?: string;
+      attributes?: Record<string, unknown>;
+    }
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(`/api/v2/products/${encodeURIComponent(productId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  /**
+   * Assign or unassign a family to a product.
+   * Pass empty string to unassign.
+   * Warning: Changing family may cause data loss. Cannot assign to variant products.
+   */
+  async assignProductFamily(
+    productId: string,
+    familyId: string
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/family`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ product_family_id: familyId }),
+      }
+    );
+  }
+
+  /**
+   * Link an existing category to a product.
+   */
+  async linkProductCategory(
+    productId: string,
+    categoryId: string
+  ): Promise<PlytixResult<PlytixCategory>> {
+    return this.request<PlytixCategory>(
+      `/api/v2/products/${encodeURIComponent(productId)}/categories`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ id: categoryId }),
+      }
+    );
+  }
+
+  /**
+   * Unlink a category from a product. Category is not deleted.
+   */
+  async unlinkProductCategory(
+    productId: string,
+    categoryId: string
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/categories/${encodeURIComponent(categoryId)}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
   // Variants (v1 API - write operations)
   // ─────────────────────────────────────────────────────────────
 

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -41,5 +41,99 @@ export function registerCategoryTools(server: McpServer, client: PlytixClient) {
     }
   );
 
-  // TODO: categories.link / categories.unlink after verifying payload shapes
+  // LINK category to product
+  registerTool<{ product_id: string; category_id: string }>(
+    server,
+    'categories_link',
+    {
+      title: 'Link Category',
+      description: 'Link an existing category to a product',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID'),
+        category_id: z.string().min(1).describe('The category ID to link'),
+      },
+    },
+    async ({ product_id, category_id }) => {
+      try {
+        const result = await client.linkProductCategory(product_id, category_id);
+        const linked = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  category: linked
+                    ? { id: linked.id, name: linked.name, path: linked.path }
+                    : { id: category_id },
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error linking category: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // UNLINK category from product
+  registerTool<{ product_id: string; category_id: string }>(
+    server,
+    'categories_unlink',
+    {
+      title: 'Unlink Category',
+      description: 'Remove a category link from a product. The category itself is not deleted.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID'),
+        category_id: z.string().min(1).describe('The category ID to unlink'),
+      },
+    },
+    async ({ product_id, category_id }) => {
+      try {
+        await client.unlinkProductCategory(product_id, category_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  category_id,
+                  action: 'unlinked',
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error unlinking category: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
 }

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -332,10 +332,10 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
           .optional()
           .describe('Custom attributes as key-value pairs (use attribute labels as keys)'),
         category_ids: z
-          .array(z.string())
+          .array(z.string().min(1))
           .optional()
           .describe('Category IDs to link to this product'),
-        asset_ids: z.array(z.string()).optional().describe('Asset IDs to link to this product'),
+        asset_ids: z.array(z.string().min(1)).optional().describe('Asset IDs to link to this product'),
       },
     },
     async ({ sku, label, status, attributes, category_ids, asset_ids }) => {
@@ -422,6 +422,13 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
         if (label !== undefined) data.label = label;
         if (status !== undefined) data.status = status;
         if (attributes !== undefined) data.attributes = attributes;
+
+        if (Object.keys(data).length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No fields provided to update' }],
+            isError: true,
+          };
+        }
 
         const result = await client.updateProduct(product_id, data);
         const updated = result.data?.[0];

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -341,14 +341,23 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     async ({ sku, label, status, attributes, category_ids, asset_ids }) => {
       try {
         const data: Parameters<typeof client.createProduct>[0] = { sku };
-        if (label) data.label = label;
-        if (status) data.status = status;
-        if (attributes) data.attributes = attributes;
+        if (label !== undefined) data.label = label;
+        if (status !== undefined) data.status = status;
+        if (attributes !== undefined) data.attributes = attributes;
         if (category_ids?.length) data.categories = category_ids.map((id) => ({ id }));
         if (asset_ids?.length) data.assets = asset_ids.map((id) => ({ id }));
 
         const result = await client.createProduct(data);
         const created = result.data?.[0];
+
+        if (!created?.id) {
+          return {
+            content: [
+              { type: 'text', text: 'Product creation failed: no ID returned from API' },
+            ],
+            isError: true,
+          };
+        }
 
         return {
           content: [
@@ -357,8 +366,8 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
               text: JSON.stringify(
                 {
                   success: true,
-                  id: created?.id,
-                  created: created?.created,
+                  id: created.id,
+                  created: created.created,
                 },
                 null,
                 2
@@ -417,6 +426,15 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
         const result = await client.updateProduct(product_id, data);
         const updated = result.data?.[0];
 
+        if (!updated?.id) {
+          return {
+            content: [
+              { type: 'text', text: `Product update failed: no response for ${product_id}` },
+            ],
+            isError: true,
+          };
+        }
+
         return {
           content: [
             {
@@ -424,8 +442,8 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
               text: JSON.stringify(
                 {
                   success: true,
-                  id: updated?.id,
-                  modified: updated?.modified,
+                  id: updated.id,
+                  modified: updated.modified,
                 },
                 null,
                 2
@@ -471,6 +489,15 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
         const result = await client.assignProductFamily(product_id, family_id);
         const updated = result.data?.[0];
 
+        if (!updated?.id) {
+          return {
+            content: [
+              { type: 'text', text: `Family assignment failed: no response for ${product_id}` },
+            ],
+            isError: true,
+          };
+        }
+
         return {
           content: [
             {
@@ -478,10 +505,10 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
               text: JSON.stringify(
                 {
                   success: true,
-                  id: updated?.id,
+                  id: updated.id,
                   family_id: family_id || null,
                   action: family_id ? 'assigned' : 'unassigned',
-                  modified: updated?.modified,
+                  modified: updated.modified,
                 },
                 null,
                 2


### PR DESCRIPTION
## Summary
- Add `products.create`, `products.update`, `products.assign_family` tools
- Add `categories.link`, `categories.unlink` tools  
- Client methods for all write operations
- Updated CLAUDE.md with new tools table

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Manual test: create/update product via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces write capabilities to the Plytix MCP server and client.
> 
> - Adds client methods: `createProduct`, `updateProduct`, `assignProductFamily`, `linkProductCategory`, `unlinkProductCategory`
> - Registers MCP tools: `products.create`, `products.update`, `products.assign_family`, `categories.link`, `categories.unlink`
> - Updates `CLAUDE.md` with write operations table and session notes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bd09797d07651a350df1cf6e2e81d4e7192b773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->