### PR TITLE
feat: add attribute get and get_options primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ src/
 | `families.list` | List/search product families |
 | `families.get` | Get single family with linked attributes |
 | `attributes.list` | List all attributes (system + custom) |
+| `attributes.get` | Get full details for a single attribute by label |
+| `attributes.get_options` | Get allowed values for a dropdown/multiselect attribute |
 | `attributes.filters` | Get available search filters |
 | `assets.list` | List assets linked to a product |
 | `categories.list` | List categories linked to a product |

--- a/src/client.ts
+++ b/src/client.ts
@@ -350,14 +350,14 @@ export class PlytixClient {
       return this.attributeCache.byLabel;
     }
 
-    // Fetch all attribute IDs, then details in parallel
+    // Fetch all attribute IDs, then details in parallel (graceful partial failure)
     const attrIds = await this.searchAttributeIds();
-    const attrDetails = await Promise.all(attrIds.map((id) => this.getAttributeById(id)));
+    const results = await Promise.allSettled(attrIds.map((id) => this.getAttributeById(id)));
 
     const byLabel = new Map<string, PlytixAttributeDetail>();
-    for (const attr of attrDetails) {
-      if (attr?.label) {
-        byLabel.set(attr.label, attr);
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value?.label) {
+        byLabel.set(result.value.label, result.value);
       }
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -376,11 +376,12 @@ export class PlytixClient {
 
   /**
    * Get options for a dropdown/multiselect attribute by label.
-   * Returns empty array if attribute not found or has no options.
+   * Returns null if attribute not found, empty array if attribute exists but has no options.
    */
-  async getAttributeOptions(label: string): Promise<string[]> {
+  async getAttributeOptions(label: string): Promise<string[] | null> {
     const attr = await this.getAttributeByLabel(label);
-    return attr?.options ?? [];
+    if (!attr) return null;
+    return attr.options ?? [];
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -68,6 +68,128 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
   );
 
   // ─────────────────────────────────────────────────────────────
+  // attributes.get - Get full attribute details by label
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ label: string }>(
+    server,
+    'attributes_get',
+    {
+      title: 'Get Attribute',
+      description:
+        'Get full details for a single attribute by its label (snake_case identifier like "head_material"). ' +
+        'Returns type, options (for dropdowns), groups, and other metadata. ' +
+        'Use this to inspect a specific attribute or get its allowed values.',
+      inputSchema: {
+        label: z
+          .string()
+          .describe('Attribute label (snake_case identifier, e.g., "head_material")'),
+      },
+    },
+    async ({ label }) => {
+      try {
+        const attr = await client.getAttributeByLabel(label);
+
+        if (!attr) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ error: 'not_found', label, message: `Attribute "${label}" not found` }, null, 2),
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  id: attr.id,
+                  label: attr.label,
+                  name: attr.name,
+                  type_class: attr.type_class,
+                  options: attr.options ?? [],
+                  options_count: attr.options?.length ?? 0,
+                  groups: attr.groups ?? [],
+                  description: attr.description,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error getting attribute: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // attributes.get_options - Get allowed values for dropdown/multiselect
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ label: string }>(
+    server,
+    'attributes_get_options',
+    {
+      title: 'Get Attribute Options',
+      description:
+        'Get the allowed values (options) for a dropdown or multiselect attribute. ' +
+        'Returns an array of valid option strings. ' +
+        'Use this to validate enum values or sync options to external systems.',
+      inputSchema: {
+        label: z
+          .string()
+          .describe('Attribute label (snake_case identifier, e.g., "head_material")'),
+      },
+    },
+    async ({ label }) => {
+      try {
+        const options = await client.getAttributeOptions(label);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  label,
+                  options,
+                  count: options.length,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error getting attribute options: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
   // attributes.filters - Get available search filters
   // ─────────────────────────────────────────────────────────────
 

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -92,12 +92,8 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
 
         if (!attr) {
           return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ error: 'not_found', label, message: `Attribute "${label}" not found` }, null, 2),
-              },
-            ],
+            content: [{ type: 'text', text: `Attribute not found: ${label}` }],
+            isError: true,
           };
         }
 

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -155,6 +155,13 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
       try {
         const options = await client.getAttributeOptions(label);
 
+        if (options === null) {
+          return {
+            content: [{ type: 'text', text: `Attribute not found: ${label}` }],
+            isError: true,
+          };
+        }
+
         return {
           content: [
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,28 @@ export interface PlytixAttribute {
   options?: unknown[];
 }
 
+/**
+ * Full attribute detail from GET /attributes/product/{id}
+ *
+ * Note: Plytix API naming is confusing:
+ * - API "label" = snake_case identifier (e.g., "head_material")
+ * - API "name" = human-readable display name (e.g., "Head Material")
+ */
+export interface PlytixAttributeDetail {
+  id: string;
+  label: string;          // snake_case identifier (e.g., "head_material")
+  name: string;           // display name (e.g., "Head Material")
+  type_class: string;     // "DropdownAttribute", "MultiSelectAttribute", "TextAttribute", etc.
+  options?: string[];     // allowed values for dropdown/multiselect
+  groups?: string[];      // attribute groups this belongs to
+  description?: string;
+  required?: boolean;
+  searchable?: boolean;
+  filterable?: boolean;
+  created?: string;
+  modified?: string;
+}
+
 export interface PlytixFilterDefinition {
   field: string;
   type: string;


### PR DESCRIPTION
## Summary

- Add `attributes_get` tool to get full details for a single attribute by label
- Add `attributes_get_options` tool to get allowed values for dropdown/multiselect attributes
- Add supporting client methods and `PlytixAttributeDetail` type

## Why

These primitives enable agent-native workflows for dropdown option sync. Instead of bundling sync logic into the MCP server, agents can now compose these tools with Airtable MCP to achieve the same outcome flexibly.

Example agent workflow:
```
1. plytix: attributes_get_options("head_material") → ["PVDF | Kynar", ...]
2. airtable: list_records(filter: plytix_id = "head_material") → current values
3. agent: compute diff
4. airtable: update_records(...) if different
```

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (33 tests)
- [x] `npm run build` succeeds
- [ ] Manual test: call `attributes_get("head_material")` via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new API calls that fetch all attribute IDs and then fan out to per-attribute detail requests, which could impact latency/rate limits despite the 5-minute cache.
> 
> **Overview**
> Adds new MCP read tools `attributes.get` and `attributes.get_options` to fetch full attribute metadata (by label) and to return allowed option values for dropdown/multiselect attributes.
> 
> Extends `PlytixClient` with attribute search-by-ID + fetch-by-ID helpers and a 5-minute in-memory label-indexed cache to avoid repeated API calls; introduces `PlytixAttributeDetail` typing and documents the new tools in `CLAUDE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad169b5d76ba71b3b130ebd5c2c9d5e73d3d4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->