### PR TITLE
feat: add atomic product attribute and relationship write tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,14 @@ src/
     lookup.ts           # Smart product lookup with staged search
     index.ts            # Barrel export
   tools/
-    products.ts         # Product tools (lookup, get, search, find)
+    products.ts         # Product tools (lookup, get, search, find, writes)
     families.ts         # Family tools (list, get)
-    attributes.ts       # Attribute tools (list, filters)
-    assets.ts           # Asset listing
-    categories.ts       # Category listing
-    variants.ts         # Variant listing
+    attributes.ts       # Attribute metadata tools
+    product-attributes.ts # Atomic product attribute write tools
+    assets.ts           # Asset list/link/unlink tools
+    categories.ts       # Category list/link/unlink tools
+    variants.ts         # Variant list/resync tools
+    relationships.ts    # Product relationship write tools
   supplyline/           # Supplyline-specific customizations
     index.ts            # Supplyline tool registration
 ```
@@ -69,9 +71,16 @@ src/
 | `products.create` | Create a new product (SKU required) |
 | `products.update` | Update product attributes (PATCH - partial update) |
 | `products.assign_family` | Assign/unassign family (⚠️ may cause data loss) |
+| `products.set_attribute` | Set one product attribute atomically |
+| `products.clear_attribute` | Clear one product attribute atomically |
+| `assets.link` | Link existing asset to product |
+| `assets.unlink` | Unlink asset from product |
 | `categories.link` | Link existing category to product |
 | `categories.unlink` | Unlink category from product |
 | `variants.resync` | Restore variant attributes to inherit from parent |
+| `relationships.link_product` | Link one related product row |
+| `relationships.unlink_product` | Unlink one related product row |
+| `relationships.set_quantity` | Update quantity for one related product row |
 
 ## Smart Lookup System
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A **lightweight, stateless Model Context Protocol (MCP) server** that provides AI assistants with live access to Plytix PIM (Product Information Management) data. This server enables AI tools like Claude Desktop, Claude mobile app, and other MCP clients to search, look up, and retrieve product information directly from the Plytix API.
 
-> **Note:** This is a read-only query tool for live API access. For sync, caching, or ETL workflows, see [supplyline-sync](https://github.com/Supplyline/supplyline-sync).
+> **Note:** This is a stateless live API tool for read and write operations. For sync, caching, or ETL workflows, see [supplyline-sync](https://github.com/Supplyline/supplyline-sync).
 
 ## Features
 
-- **11 MCP Tools** for comprehensive Plytix PIM access
+- **29 MCP tools (stdio) and 19 MCP tools (remote worker)**
 - **Smart product lookup** with automatic identifier detection (SKU, MPN, GTIN, label)
 - **Family & inheritance tracking** with overwritten_attributes support
 - **Schema discovery** for attributes and search filters
@@ -117,6 +117,11 @@ For detailed setup instructions, see [docs/remote-setup.md](docs/remote-setup.md
 | `products_get` | Get single product by ID with full details and `overwritten_attributes` |
 | `products_search` | Advanced search with filters, pagination, and sorting |
 | `products_find` | Simple multi-criteria search (SKU, MPN, MNO, GTIN, label, fuzzy) |
+| `products_create` | Create a new product |
+| `products_update` | Partial update to product fields/attributes |
+| `products_assign_family` | Assign or unassign a product family |
+| `products_set_attribute` | Atomic set of one attribute value |
+| `products_clear_attribute` | Atomic clear of one attribute value |
 
 ### Family Tools
 
@@ -130,6 +135,8 @@ For detailed setup instructions, see [docs/remote-setup.md](docs/remote-setup.md
 | Tool | Description |
 |------|-------------|
 | `attributes_list` | List all attributes (system + custom) with types and options |
+| `attributes_get` | Get full metadata for one attribute label |
+| `attributes_get_options` | Get allowed values for a selectable attribute |
 | `attributes_filters` | Get available search filters and operators |
 
 ### Related Data Tools
@@ -137,8 +144,24 @@ For detailed setup instructions, see [docs/remote-setup.md](docs/remote-setup.md
 | Tool | Description |
 |------|-------------|
 | `assets_list` | List assets (images, videos, documents) linked to a product |
+| `assets_link` | Link an asset to a product |
+| `assets_unlink` | Unlink an asset from a product |
 | `categories_list` | List categories associated with a product |
+| `categories_link` | Link a category to a product |
+| `categories_unlink` | Unlink a category from a product |
 | `variants_list` | List variants for a product |
+| `variants_resync` | Reset variant attributes to inherit parent values |
+| `relationships_link_product` | Link one related product row in a relationship |
+| `relationships_unlink_product` | Unlink one related product row in a relationship |
+| `relationships_set_quantity` | Update quantity for one related product row |
+
+### Identifier Utilities
+
+| Tool | Description |
+|------|-------------|
+| `identifier_detect` | Detect identifier type from raw value |
+| `identifier_normalize` | Normalize identifier for matching |
+| `match_score` | Score identifier-product match confidence |
 
 ## Smart Lookup System
 
@@ -218,12 +241,14 @@ src/
     identifier.ts       # Identifier type detection
     lookup.ts           # Smart lookup with staged search
   tools/
-    products.ts         # Product tools (lookup, get, search, find)
+    products.ts         # Product tools (lookup, get, search, find, write ops)
     families.ts         # Family tools (list, get)
-    attributes.ts       # Attribute tools (list, filters)
-    assets.ts           # Asset listing
-    categories.ts       # Category listing
-    variants.ts         # Variant listing
+    attributes.ts       # Attribute metadata tools
+    product-attributes.ts # Atomic product attribute write tools
+    assets.ts           # Asset list/link/unlink tools
+    categories.ts       # Category list/link/unlink tools
+    variants.ts         # Variant list/resync tools
+    relationships.ts    # Product relationship write tools
   supplyline/           # Supplyline-specific customizations
 wrangler.toml           # Cloudflare Workers configuration
 docs/

--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -217,6 +217,14 @@ The Plytix API has rate limits. The server handles backoff automatically, but re
 | `families_get` | Get single family with linked attributes |
 | `attributes_list` | List all attributes (system + custom) |
 | `attributes_filters` | Get available search filters |
+| `products_set_attribute` | Set one product attribute atomically |
+| `products_clear_attribute` | Clear one product attribute atomically |
 | `assets_list` | List assets linked to a product |
+| `assets_link` | Link asset to a product |
+| `assets_unlink` | Unlink asset from a product |
 | `categories_list` | List categories linked to a product |
 | `variants_list` | List variants for a product |
+| `variants_resync` | Reset variant attributes to inherit from parent |
+| `relationships_link_product` | Link one related product row in a relationship |
+| `relationships_unlink_product` | Unlink one related product row in a relationship |
+| `relationships_set_quantity` | Update quantity for one related product row |

--- a/src/client.ts
+++ b/src/client.ts
@@ -436,6 +436,39 @@ export class PlytixClient {
   }
 
   /**
+   * Link an existing asset to a product.
+   * Optionally attach it to a media attribute label.
+   */
+  async linkProductAsset(
+    productId: string,
+    assetId: string,
+    attributeLabel?: string
+  ): Promise<PlytixResult<PlytixAsset>> {
+    const body: { id: string; attribute_label?: string } = { id: assetId };
+    if (attributeLabel !== undefined) {
+      body.attribute_label = attributeLabel;
+    }
+
+    return this.request<PlytixAsset>(`/api/v2/products/${encodeURIComponent(productId)}/assets`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Unlink an asset from a product. Asset is not deleted from the account.
+   */
+  async unlinkProductAsset(
+    productId: string,
+    assetId: string
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/assets/${encodeURIComponent(assetId)}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  /**
    * Assign or unassign a family to a product.
    * Pass empty string to unassign.
    * Warning: Changing family may cause data loss. Cannot assign to variant products.
@@ -479,6 +512,63 @@ export class PlytixClient {
     return this.request<void>(
       `/api/v2/products/${encodeURIComponent(productId)}/categories/${encodeURIComponent(categoryId)}`,
       { method: 'DELETE' }
+    );
+  }
+
+  /**
+   * Add related products to a relationship for a product.
+   */
+  async linkProductRelationship(
+    productId: string,
+    relationshipId: string,
+    productRelationships: Array<{ product_id: string; quantity?: number }>
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          product_relationships: productRelationships,
+        }),
+      }
+    );
+  }
+
+  /**
+   * Remove related products from a relationship for a product.
+   */
+  async unlinkProductRelationship(
+    productId: string,
+    relationshipId: string,
+    relatedProductIds: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'DELETE',
+        body: JSON.stringify({
+          product_relationships: relatedProductIds,
+        }),
+      }
+    );
+  }
+
+  /**
+   * Update relationship attributes for related products (e.g., quantity).
+   */
+  async updateProductRelationship(
+    productId: string,
+    relationshipId: string,
+    productRelationships: Array<{ product_id: string; quantity?: number }>
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          product_relationships: productRelationships,
+        }),
+      }
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { registerAssetTools } from './tools/assets.js';
 import { registerCategoryTools } from './tools/categories.js';
 import { registerVariantTools } from './tools/variants.js';
 import { registerIdentifierTools } from './tools/identifier.js';
+import { registerProductAttributeTools } from './tools/product-attributes.js';
+import { registerRelationshipTools } from './tools/relationships.js';
 
 async function main() {
   const server = new McpServer({
@@ -32,6 +34,8 @@ async function main() {
   registerAssetTools(server, client);
   registerCategoryTools(server, client);
   registerVariantTools(server, client);
+  registerProductAttributeTools(server, client);
+  registerRelationshipTools(server, client);
   registerIdentifierTools(server);
 
   const transport = new StdioServerTransport();

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -41,5 +41,103 @@ export function registerAssetTools(server: McpServer, client: PlytixClient) {
     }
   );
 
-  // TODO: assets.link / assets.unlink will be added after confirming payload shapes
+  // LINK asset to product
+  registerTool<{ product_id: string; asset_id: string; attribute_label?: string }>(
+    server,
+    'assets_link',
+    {
+      title: 'Link Asset',
+      description:
+        'Link an existing asset to a product. Optionally target a specific media attribute.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID'),
+        asset_id: z.string().min(1).describe('The asset ID to link'),
+        attribute_label: z
+          .string()
+          .optional()
+          .describe('Optional media attribute label to assign the asset to'),
+      },
+    },
+    async ({ product_id, asset_id, attribute_label }) => {
+      try {
+        const result = await client.linkProductAsset(product_id, asset_id, attribute_label);
+        const linked = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  asset: linked ? { id: linked.id, name: linked.name, url: linked.url } : { id: asset_id },
+                  ...(attribute_label ? { attribute_label } : {}),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error linking asset: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // UNLINK asset from product
+  registerTool<{ product_id: string; asset_id: string }>(
+    server,
+    'assets_unlink',
+    {
+      title: 'Unlink Asset',
+      description: 'Remove an asset link from a product. The asset itself is not deleted.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID'),
+        asset_id: z.string().min(1).describe('The asset ID to unlink'),
+      },
+    },
+    async ({ product_id, asset_id }) => {
+      try {
+        await client.unlinkProductAsset(product_id, asset_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  asset_id,
+                  action: 'unlinked',
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error unlinking asset: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
 }

--- a/src/tools/product-attributes.ts
+++ b/src/tools/product-attributes.ts
@@ -9,6 +9,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
 import type { PlytixAttributeDetail } from '../types.js';
 import { registerTool } from './register.js';
+import { stripAttributesPrefix } from '../utils/attribute-labels.js';
 
 export function registerProductAttributeTools(server: McpServer, client: PlytixClient) {
   // ─────────────────────────────────────────────────────────────
@@ -41,7 +42,7 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
           };
         }
 
-        const normalizedLabel = normalizeAttributeLabel(attribute_label);
+        const normalizedLabel = stripAttributesPrefix(attribute_label);
         if (!normalizedLabel) {
           return {
             content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
@@ -124,7 +125,7 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
     },
     async ({ product_id, attribute_label }) => {
       try {
-        const normalizedLabel = normalizeAttributeLabel(attribute_label);
+        const normalizedLabel = stripAttributesPrefix(attribute_label);
         if (!normalizedLabel) {
           return {
             content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
@@ -176,11 +177,6 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
       }
     }
   );
-}
-
-function normalizeAttributeLabel(label: string): string {
-  const trimmed = label.trim();
-  return trimmed.startsWith('attributes.') ? trimmed.slice('attributes.'.length) : trimmed;
 }
 
 function validateAttributeValue(attribute: PlytixAttributeDetail, value: unknown): string | null {

--- a/src/tools/product-attributes.ts
+++ b/src/tools/product-attributes.ts
@@ -1,0 +1,216 @@
+/**
+ * Product Attribute Write Tools
+ *
+ * Atomic write operations for setting and clearing a single product attribute.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PlytixClient } from '../client.js';
+import type { PlytixAttributeDetail } from '../types.js';
+import { registerTool } from './register.js';
+
+export function registerProductAttributeTools(server: McpServer, client: PlytixClient) {
+  // ─────────────────────────────────────────────────────────────
+  // products_set_attribute - Set a single attribute value
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ product_id: string; attribute_label: string; value: unknown }>(
+    server,
+    'products_set_attribute',
+    {
+      title: 'Set Product Attribute',
+      description:
+        'Set a single product attribute value atomically. ' +
+        'Use snake_case labels (e.g., "head_material"). The "attributes." prefix is optional.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID to update'),
+        attribute_label: z
+          .string()
+          .min(1)
+          .describe('Attribute label (snake_case, e.g., "head_material" or "attributes.head_material")'),
+        value: z.unknown().describe('Attribute value to set'),
+      },
+    },
+    async ({ product_id, attribute_label, value }) => {
+      try {
+        if (value === null) {
+          return {
+            content: [{ type: 'text', text: 'Value cannot be null. Use products_clear_attribute instead.' }],
+            isError: true,
+          };
+        }
+
+        const normalizedLabel = normalizeAttributeLabel(attribute_label);
+        if (!normalizedLabel) {
+          return {
+            content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
+            isError: true,
+          };
+        }
+        const attribute = await client.getAttributeByLabel(normalizedLabel);
+
+        if (!attribute) {
+          return {
+            content: [{ type: 'text', text: `Attribute not found: ${normalizedLabel}` }],
+            isError: true,
+          };
+        }
+
+        const validationError = validateAttributeValue(attribute, value);
+        if (validationError) {
+          return {
+            content: [{ type: 'text', text: validationError }],
+            isError: true,
+          };
+        }
+
+        const result = await client.updateProduct(product_id, {
+          attributes: { [normalizedLabel]: value },
+        });
+        const updated = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  attribute_label: normalizedLabel,
+                  action: 'set',
+                  modified: updated?.modified,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error setting attribute: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products_clear_attribute - Clear a single attribute value
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ product_id: string; attribute_label: string }>(
+    server,
+    'products_clear_attribute',
+    {
+      title: 'Clear Product Attribute',
+      description:
+        'Clear a single product attribute value atomically by setting it to null. ' +
+        'Use snake_case labels (e.g., "head_material"). The "attributes." prefix is optional.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('The product ID to update'),
+        attribute_label: z
+          .string()
+          .min(1)
+          .describe('Attribute label (snake_case, e.g., "head_material" or "attributes.head_material")'),
+      },
+    },
+    async ({ product_id, attribute_label }) => {
+      try {
+        const normalizedLabel = normalizeAttributeLabel(attribute_label);
+        if (!normalizedLabel) {
+          return {
+            content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
+            isError: true,
+          };
+        }
+        const attribute = await client.getAttributeByLabel(normalizedLabel);
+
+        if (!attribute) {
+          return {
+            content: [{ type: 'text', text: `Attribute not found: ${normalizedLabel}` }],
+            isError: true,
+          };
+        }
+
+        const result = await client.updateProduct(product_id, {
+          attributes: { [normalizedLabel]: null },
+        });
+        const updated = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  product_id,
+                  attribute_label: normalizedLabel,
+                  action: 'cleared',
+                  modified: updated?.modified,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error clearing attribute: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+function normalizeAttributeLabel(label: string): string {
+  const trimmed = label.trim();
+  return trimmed.startsWith('attributes.') ? trimmed.slice('attributes.'.length) : trimmed;
+}
+
+function validateAttributeValue(attribute: PlytixAttributeDetail, value: unknown): string | null {
+  const options = attribute.options ?? [];
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  // For selectable attributes, enforce known option values to fail fast.
+  if (attribute.type_class === 'DropdownAttribute') {
+    if (typeof value !== 'string') {
+      return `Attribute "${attribute.label}" expects a single string option`;
+    }
+    if (!options.includes(value)) {
+      return `Invalid value for "${attribute.label}". Allowed options: ${options.join(', ')}`;
+    }
+    return null;
+  }
+
+  if (attribute.type_class === 'MultiSelectAttribute') {
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+      return `Attribute "${attribute.label}" expects an array of string options`;
+    }
+
+    const invalid = value.filter((v) => !options.includes(v));
+    if (invalid.length > 0) {
+      return `Invalid option(s) for "${attribute.label}": ${invalid.join(', ')}`;
+    }
+  }
+
+  return null;
+}

--- a/src/tools/relationships.ts
+++ b/src/tools/relationships.ts
@@ -1,0 +1,197 @@
+/**
+ * Product Relationship Tools
+ *
+ * Atomic write operations for linking/unlinking products through a relationship.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PlytixClient } from '../client.js';
+import { registerTool } from './register.js';
+
+export function registerRelationshipTools(server: McpServer, client: PlytixClient) {
+  // ─────────────────────────────────────────────────────────────
+  // relationships_link_product - Link one related product
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{
+    product_id: string;
+    relationship_id: string;
+    related_product_id: string;
+    quantity?: number;
+  }>(
+    server,
+    'relationships_link_product',
+    {
+      title: 'Link Related Product',
+      description:
+        'Link one product to another under a specific relationship. ' +
+        'If quantity is provided, it is stored in the relationship row.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('Primary product ID'),
+        relationship_id: z.string().min(1).describe('Relationship definition ID'),
+        related_product_id: z.string().min(1).describe('Related product ID to link'),
+        quantity: z.number().positive().optional().describe('Optional relationship quantity'),
+      },
+    },
+    async ({ product_id, relationship_id, related_product_id, quantity }) => {
+      try {
+        await client.linkProductRelationship(product_id, relationship_id, [
+          {
+            product_id: related_product_id,
+            ...(quantity !== undefined ? { quantity } : {}),
+          },
+        ]);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'linked',
+                  product_id,
+                  relationship_id,
+                  related_product_id,
+                  ...(quantity !== undefined ? { quantity } : {}),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error linking relationship: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // relationships_unlink_product - Unlink one related product
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{
+    product_id: string;
+    relationship_id: string;
+    related_product_id: string;
+  }>(
+    server,
+    'relationships_unlink_product',
+    {
+      title: 'Unlink Related Product',
+      description:
+        'Unlink one related product from a relationship on the primary product.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('Primary product ID'),
+        relationship_id: z.string().min(1).describe('Relationship definition ID'),
+        related_product_id: z.string().min(1).describe('Related product ID to unlink'),
+      },
+    },
+    async ({ product_id, relationship_id, related_product_id }) => {
+      try {
+        await client.unlinkProductRelationship(product_id, relationship_id, [related_product_id]);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'unlinked',
+                  product_id,
+                  relationship_id,
+                  related_product_id,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error unlinking relationship: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // relationships_set_quantity - Update one relationship row
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{
+    product_id: string;
+    relationship_id: string;
+    related_product_id: string;
+    quantity: number;
+  }>(
+    server,
+    'relationships_set_quantity',
+    {
+      title: 'Set Relationship Quantity',
+      description:
+        'Set quantity for a single related product row in a relationship.',
+      inputSchema: {
+        product_id: z.string().min(1).describe('Primary product ID'),
+        relationship_id: z.string().min(1).describe('Relationship definition ID'),
+        related_product_id: z.string().min(1).describe('Related product ID to update'),
+        quantity: z.number().nonnegative().describe('Quantity value to store'),
+      },
+    },
+    async ({ product_id, relationship_id, related_product_id, quantity }) => {
+      try {
+        await client.updateProductRelationship(product_id, relationship_id, [
+          { product_id: related_product_id, quantity },
+        ]);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'quantity_updated',
+                  product_id,
+                  relationship_id,
+                  related_product_id,
+                  quantity,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error updating relationship quantity: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/utils/attribute-labels.ts
+++ b/src/utils/attribute-labels.ts
@@ -1,0 +1,8 @@
+/**
+ * Attribute label helpers shared across stdio and worker runtimes.
+ */
+
+export function stripAttributesPrefix(label: string): string {
+  const trimmed = label.trim();
+  return trimmed.startsWith('attributes.') ? trimmed.slice('attributes.'.length) : trimmed;
+}

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -245,6 +245,91 @@ export class WorkerPlytixClient {
     return this.request<PlytixProduct>(`/api/v2/products/${encodeURIComponent(productId)}/variants`);
   }
 
+  async updateProduct(
+    productId: string,
+    data: {
+      label?: string;
+      status?: string;
+      attributes?: Record<string, unknown>;
+    }
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(`/api/v2/products/${encodeURIComponent(productId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async linkProductAsset(
+    productId: string,
+    assetId: string,
+    attributeLabel?: string
+  ): Promise<PlytixResult<PlytixAsset>> {
+    const body: { id: string; attribute_label?: string } = { id: assetId };
+    if (attributeLabel !== undefined) {
+      body.attribute_label = attributeLabel;
+    }
+
+    return this.request<PlytixAsset>(`/api/v2/products/${encodeURIComponent(productId)}/assets`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  async unlinkProductAsset(productId: string, assetId: string): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/assets/${encodeURIComponent(assetId)}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  async linkProductRelationship(
+    productId: string,
+    relationshipId: string,
+    productRelationships: Array<{ product_id: string; quantity?: number }>
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          product_relationships: productRelationships,
+        }),
+      }
+    );
+  }
+
+  async unlinkProductRelationship(
+    productId: string,
+    relationshipId: string,
+    relatedProductIds: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'DELETE',
+        body: JSON.stringify({
+          product_relationships: relatedProductIds,
+        }),
+      }
+    );
+  }
+
+  async updateProductRelationship(
+    productId: string,
+    relationshipId: string,
+    productRelationships: Array<{ product_id: string; quantity?: number }>
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/relationships/${encodeURIComponent(relationshipId)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          product_relationships: productRelationships,
+        }),
+      }
+    );
+  }
+
   // ─────────────────────────────────────────────────────────────
   // Families (v1 API)
   // ─────────────────────────────────────────────────────────────

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -92,6 +92,11 @@ function getCorsHeaders(request: Request): Record<string, string> {
   return headers;
 }
 
+function normalizeAttributeLabel(label: string): string {
+  const trimmed = label.trim();
+  return trimmed.startsWith('attributes.') ? trimmed.slice('attributes.'.length) : trimmed;
+}
+
 // ─────────────────────────────────────────────────────────────
 // Tool Definitions
 // ─────────────────────────────────────────────────────────────
@@ -237,6 +242,34 @@ const TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'products_set_attribute',
+    description:
+      'Set a single product attribute value atomically. ' +
+      'Use snake_case labels (e.g., "head_material").',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID to update' },
+        attribute_label: { type: 'string', description: 'Attribute label (snake_case)' },
+        value: { description: 'Attribute value to set' },
+      },
+      required: ['product_id', 'attribute_label', 'value'],
+    },
+  },
+  {
+    name: 'products_clear_attribute',
+    description:
+      'Clear a single product attribute value atomically by setting it to null.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID to update' },
+        attribute_label: { type: 'string', description: 'Attribute label (snake_case)' },
+      },
+      required: ['product_id', 'attribute_label'],
+    },
+  },
+  {
     name: 'assets_list',
     description: 'List assets linked to a product.',
     inputSchema: {
@@ -245,6 +278,34 @@ const TOOLS: ToolDefinition[] = [
         product_id: { type: 'string', description: 'The product ID' },
       },
       required: ['product_id'],
+    },
+  },
+  {
+    name: 'assets_link',
+    description: 'Link an existing asset to a product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID' },
+        asset_id: { type: 'string', description: 'The asset ID to link' },
+        attribute_label: {
+          type: 'string',
+          description: 'Optional media attribute label to assign the asset to',
+        },
+      },
+      required: ['product_id', 'asset_id'],
+    },
+  },
+  {
+    name: 'assets_unlink',
+    description: 'Unlink an asset from a product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID' },
+        asset_id: { type: 'string', description: 'The asset ID to unlink' },
+      },
+      required: ['product_id', 'asset_id'],
     },
   },
   {
@@ -293,6 +354,50 @@ const TOOLS: ToolDefinition[] = [
         },
       },
       required: ['parent_product_id', 'attribute_labels', 'variant_ids'],
+    },
+  },
+  {
+    name: 'relationships_link_product',
+    description:
+      'Link one product to another under a specific relationship.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Primary product ID' },
+        relationship_id: { type: 'string', description: 'Relationship definition ID' },
+        related_product_id: { type: 'string', description: 'Related product ID to link' },
+        quantity: { type: 'number', description: 'Optional relationship quantity' },
+      },
+      required: ['product_id', 'relationship_id', 'related_product_id'],
+    },
+  },
+  {
+    name: 'relationships_unlink_product',
+    description:
+      'Unlink one related product from a relationship on the primary product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Primary product ID' },
+        relationship_id: { type: 'string', description: 'Relationship definition ID' },
+        related_product_id: { type: 'string', description: 'Related product ID to unlink' },
+      },
+      required: ['product_id', 'relationship_id', 'related_product_id'],
+    },
+  },
+  {
+    name: 'relationships_set_quantity',
+    description:
+      'Set quantity for a single related product row in a relationship.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'Primary product ID' },
+        relationship_id: { type: 'string', description: 'Relationship definition ID' },
+        related_product_id: { type: 'string', description: 'Related product ID to update' },
+        quantity: { type: 'number', description: 'Quantity value to store' },
+      },
+      required: ['product_id', 'relationship_id', 'related_product_id', 'quantity'],
     },
   },
 ];
@@ -528,6 +633,86 @@ const toolHandlers: Record<string, ToolHandler> = {
     };
   },
 
+  async products_set_attribute(args, client) {
+    const productId = args.product_id as string;
+    const attributeLabel = normalizeAttributeLabel(args.attribute_label as string);
+    const value = args.value;
+
+    if (!attributeLabel) {
+      return {
+        content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
+        isError: true,
+      };
+    }
+
+    if (value === null) {
+      return {
+        content: [{ type: 'text', text: 'Value cannot be null. Use products_clear_attribute instead.' }],
+        isError: true,
+      };
+    }
+
+    const result = await client.updateProduct(productId, {
+      attributes: { [attributeLabel]: value },
+    });
+    const updated = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              attribute_label: attributeLabel,
+              action: 'set',
+              modified: updated?.modified,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async products_clear_attribute(args, client) {
+    const productId = args.product_id as string;
+    const attributeLabel = normalizeAttributeLabel(args.attribute_label as string);
+
+    if (!attributeLabel) {
+      return {
+        content: [{ type: 'text', text: 'attribute_label cannot be empty' }],
+        isError: true,
+      };
+    }
+
+    const result = await client.updateProduct(productId, {
+      attributes: { [attributeLabel]: null },
+    });
+    const updated = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              attribute_label: attributeLabel,
+              action: 'cleared',
+              modified: updated?.modified,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
   async assets_list(args, client) {
     const productId = args.product_id as string;
     const result = await client.getProductAssets(productId);
@@ -540,6 +725,58 @@ const toolHandlers: Record<string, ToolHandler> = {
             {
               assets: result.data,
               count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async assets_link(args, client) {
+    const productId = args.product_id as string;
+    const assetId = args.asset_id as string;
+    const attributeLabel = args.attribute_label as string | undefined;
+
+    const result = await client.linkProductAsset(productId, assetId, attributeLabel);
+    const linked = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              asset: linked ? { id: linked.id, name: linked.name, url: linked.url } : { id: assetId },
+              ...(attributeLabel ? { attribute_label: attributeLabel } : {}),
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async assets_unlink(args, client) {
+    const productId = args.product_id as string;
+    const assetId = args.asset_id as string;
+
+    await client.unlinkProductAsset(productId, assetId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              asset_id: assetId,
+              action: 'unlinked',
             },
             null,
             2
@@ -608,6 +845,98 @@ const toolHandlers: Record<string, ToolHandler> = {
               parent_product_id: parentProductId,
               attributes_reset: attributeLabels,
               variants_affected: variantIds.length,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async relationships_link_product(args, client) {
+    const productId = args.product_id as string;
+    const relationshipId = args.relationship_id as string;
+    const relatedProductId = args.related_product_id as string;
+    const quantity = args.quantity as number | undefined;
+
+    await client.linkProductRelationship(productId, relationshipId, [
+      {
+        product_id: relatedProductId,
+        ...(quantity !== undefined ? { quantity } : {}),
+      },
+    ]);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'linked',
+              product_id: productId,
+              relationship_id: relationshipId,
+              related_product_id: relatedProductId,
+              ...(quantity !== undefined ? { quantity } : {}),
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async relationships_unlink_product(args, client) {
+    const productId = args.product_id as string;
+    const relationshipId = args.relationship_id as string;
+    const relatedProductId = args.related_product_id as string;
+
+    await client.unlinkProductRelationship(productId, relationshipId, [relatedProductId]);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'unlinked',
+              product_id: productId,
+              relationship_id: relationshipId,
+              related_product_id: relatedProductId,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async relationships_set_quantity(args, client) {
+    const productId = args.product_id as string;
+    const relationshipId = args.relationship_id as string;
+    const relatedProductId = args.related_product_id as string;
+    const quantity = args.quantity as number;
+
+    await client.updateProductRelationship(productId, relationshipId, [
+      { product_id: relatedProductId, quantity },
+    ]);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'quantity_updated',
+              product_id: productId,
+              relationship_id: relationshipId,
+              related_product_id: relatedProductId,
+              quantity,
             },
             null,
             2

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,7 @@
 
 import { WorkerPlytixClient } from './worker-client.js';
 import { WorkerPlytixLookup } from './worker-lookup.js';
+import { stripAttributesPrefix } from './utils/attribute-labels.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -90,11 +91,6 @@ function getCorsHeaders(request: Request): Record<string, string> {
   // This will cause browsers to block cross-origin requests from unauthorized sites
 
   return headers;
-}
-
-function normalizeAttributeLabel(label: string): string {
-  const trimmed = label.trim();
-  return trimmed.startsWith('attributes.') ? trimmed.slice('attributes.'.length) : trimmed;
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -635,7 +631,7 @@ const toolHandlers: Record<string, ToolHandler> = {
 
   async products_set_attribute(args, client) {
     const productId = args.product_id as string;
-    const attributeLabel = normalizeAttributeLabel(args.attribute_label as string);
+    const attributeLabel = stripAttributesPrefix(args.attribute_label as string);
     const value = args.value;
 
     if (!attributeLabel) {
@@ -679,7 +675,7 @@ const toolHandlers: Record<string, ToolHandler> = {
 
   async products_clear_attribute(args, client) {
     const productId = args.product_id as string;
-    const attributeLabel = normalizeAttributeLabel(args.attribute_label as string);
+    const attributeLabel = stripAttributesPrefix(args.attribute_label as string);
 
     if (!attributeLabel) {
       return {


### PR DESCRIPTION
## Summary
- add atomic product attribute tools (`products_set_attribute`, `products_clear_attribute`)
- add product relationship write tools (`relationships_link_product`, `relationships_unlink_product`, `relationships_set_quantity`)
- add asset link/unlink tools and corresponding client methods
- add stdio + worker parity for new write operations
- update README/CLAUDE/docs tool inventories

## Validation
- npm run typecheck
- npm run typecheck:worker
- npm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new write operations that can mutate product data and relationships via the live Plytix API, so mistakes in payloads/validation could cause unintended updates despite limited surface-area changes.
> 
> **Overview**
> Adds new MCP write capabilities for **atomic updates**: `products_set_attribute`/`products_clear_attribute` to set or null a single attribute (including label normalization via shared `stripAttributesPrefix`, plus option validation for dropdown/multiselect), and `relationships_link_product`/`relationships_unlink_product`/`relationships_set_quantity` to manage product relationship rows.
> 
> Extends the Plytix clients (Node + Worker) with new v2 API methods for asset link/unlink and relationship link/unlink/update, wires the new tools into both stdio (`src/index.ts`, `src/tools/assets.ts`, new tool modules) and the Cloudflare Worker tool registry/handlers (`src/worker.ts`) for parity, and updates docs/tool inventories (README, CLAUDE, remote setup) to reflect the expanded toolset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32a4d7eef539f89c36790edad77e25a3bb9887f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

