### PR TITLE
feat: worker MCP parity — 7 new tools + attribute validation

### DIFF
--- a/src/tools/product-attributes.ts
+++ b/src/tools/product-attributes.ts
@@ -7,9 +7,9 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
-import type { PlytixAttributeDetail } from '../types.js';
 import { registerTool } from './register.js';
 import { stripAttributesPrefix } from '../utils/attribute-labels.js';
+import { validateAttributeValue } from '../utils/validate-attribute.js';
 
 export function registerProductAttributeTools(server: McpServer, client: PlytixClient) {
   // ─────────────────────────────────────────────────────────────
@@ -177,36 +177,4 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
       }
     }
   );
-}
-
-function validateAttributeValue(attribute: PlytixAttributeDetail, value: unknown): string | null {
-  const options = attribute.options ?? [];
-
-  if (options.length === 0) {
-    return null;
-  }
-
-  // For selectable attributes, enforce known option values to fail fast.
-  if (attribute.type_class === 'DropdownAttribute') {
-    if (typeof value !== 'string') {
-      return `Attribute "${attribute.label}" expects a single string option`;
-    }
-    if (!options.includes(value)) {
-      return `Invalid value for "${attribute.label}". Allowed options: ${options.join(', ')}`;
-    }
-    return null;
-  }
-
-  if (attribute.type_class === 'MultiSelectAttribute') {
-    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
-      return `Attribute "${attribute.label}" expects an array of string options`;
-    }
-
-    const invalid = value.filter((v) => !options.includes(v));
-    if (invalid.length > 0) {
-      return `Invalid option(s) for "${attribute.label}": ${invalid.join(', ')}`;
-    }
-  }
-
-  return null;
 }

--- a/src/utils/validate-attribute.ts
+++ b/src/utils/validate-attribute.ts
@@ -1,0 +1,40 @@
+/**
+ * Attribute value validation shared across stdio and worker runtimes.
+ */
+
+import type { PlytixAttributeDetail } from '../types.js';
+
+/**
+ * Validate a value against an attribute's type and allowed options.
+ * Returns an error message string if invalid, null if valid.
+ */
+export function validateAttributeValue(attribute: PlytixAttributeDetail, value: unknown): string | null {
+  const options = attribute.options ?? [];
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  if (attribute.type_class === 'DropdownAttribute') {
+    if (typeof value !== 'string') {
+      return `Attribute "${attribute.label}" expects a single string option`;
+    }
+    if (!options.includes(value)) {
+      return `Invalid value for "${attribute.label}". Allowed options: ${options.join(', ')}`;
+    }
+    return null;
+  }
+
+  if (attribute.type_class === 'MultiSelectAttribute') {
+    if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+      return `Attribute "${attribute.label}" expects an array of string options`;
+    }
+
+    const invalid = value.filter((v) => !options.includes(v));
+    if (invalid.length > 0) {
+      return `Invalid option(s) for "${attribute.label}": ${invalid.join(', ')}`;
+    }
+  }
+
+  return null;
+}

--- a/src/utils/validate-attribute.ts
+++ b/src/utils/validate-attribute.ts
@@ -34,6 +34,20 @@ export function validateAttributeValue(attribute: PlytixAttributeDetail, value: 
     if (invalid.length > 0) {
       return `Invalid option(s) for "${attribute.label}": ${invalid.join(', ')}`;
     }
+    return null;
+  }
+
+  // Unknown type_class with options — do a generic membership check
+  // so new selectable types don't silently bypass validation
+  if (typeof value === 'string') {
+    if (!options.includes(value)) {
+      return `Invalid value for "${attribute.label}" (${attribute.type_class}). Allowed options: ${options.join(', ')}`;
+    }
+  } else if (Array.isArray(value)) {
+    const invalid = value.filter((v) => typeof v === 'string' && !options.includes(v));
+    if (invalid.length > 0) {
+      return `Invalid option(s) for "${attribute.label}" (${attribute.type_class}): ${invalid.join(', ')}`;
+    }
   }
 
   return null;

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -20,6 +20,7 @@ import type {
   PlytixCategory,
   PlytixFamily,
   PlytixFilterDefinition,
+  PlytixAttributeDetail,
   RateLimitInfo,
 } from './types.js';
 import { PlytixError } from './types.js';
@@ -41,6 +42,7 @@ export interface WorkerClientConfig {
 export class WorkerPlytixClient {
   private token?: PlytixAuthToken;
   private config: Required<PlytixClientConfig>;
+  private attributeCache?: Map<string, PlytixAttributeDetail>;
 
   constructor(config: WorkerClientConfig) {
     if (!config.apiKey || !config.apiPassword) {
@@ -259,6 +261,56 @@ export class WorkerPlytixClient {
     });
   }
 
+  async createProduct(data: {
+    sku: string;
+    label?: string;
+    status?: string;
+    attributes?: Record<string, unknown>;
+    categories?: Array<{ id: string }>;
+    assets?: Array<{ id: string }>;
+  }): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>('/api/v2/products', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async assignProductFamily(
+    productId: string,
+    familyId: string
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(productId)}/family`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ product_family_id: familyId }),
+      }
+    );
+  }
+
+  async linkProductCategory(
+    productId: string,
+    categoryId: string
+  ): Promise<PlytixResult<PlytixCategory>> {
+    return this.request<PlytixCategory>(
+      `/api/v2/products/${encodeURIComponent(productId)}/categories`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ id: categoryId }),
+      }
+    );
+  }
+
+  async unlinkProductCategory(
+    productId: string,
+    categoryId: string
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(productId)}/categories/${encodeURIComponent(categoryId)}`,
+      { method: 'DELETE' }
+    );
+  }
+
   async linkProductAsset(
     productId: string,
     assetId: string,
@@ -382,6 +434,82 @@ export class WorkerPlytixClient {
         custom: [],
       };
     }
+  }
+
+  /**
+   * Paginate all attribute IDs from the v1 search endpoint.
+   */
+  async searchAttributeIds(pageSize = 100): Promise<string[]> {
+    const attrIds: string[] = [];
+    let page = 1;
+
+    while (true) {
+      const result = await this.request<{ id: string }>(
+        '/api/v1/attributes/product/search',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            pagination: { page, page_size: pageSize },
+          }),
+        }
+      );
+
+      if (!result.data || result.data.length === 0) break;
+      attrIds.push(...result.data.map((a) => a.id));
+      if (result.data.length < pageSize) break;
+      page++;
+    }
+
+    return attrIds;
+  }
+
+  /**
+   * Get full attribute details by ID.
+   */
+  async getAttributeById(attrId: string): Promise<PlytixAttributeDetail | null> {
+    const result = await this.request<PlytixAttributeDetail>(
+      `/api/v1/attributes/product/${encodeURIComponent(attrId)}`
+    );
+    return result.data?.[0] ?? null;
+  }
+
+  /**
+   * Build attribute cache indexed by label.
+   * Per-request scope — no TTL needed (stateless worker).
+   */
+  private async buildAttributeCache(): Promise<Map<string, PlytixAttributeDetail>> {
+    if (this.attributeCache) return this.attributeCache;
+
+    const attrIds = await this.searchAttributeIds();
+    const results = await Promise.allSettled(attrIds.map((id) => this.getAttributeById(id)));
+
+    const byLabel = new Map<string, PlytixAttributeDetail>();
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value?.label) {
+        byLabel.set(result.value.label, result.value);
+      }
+    }
+
+    this.attributeCache = byLabel;
+    return byLabel;
+  }
+
+  /**
+   * Get full attribute details by label (snake_case identifier).
+   */
+  async getAttributeByLabel(label: string): Promise<PlytixAttributeDetail | null> {
+    const cache = await this.buildAttributeCache();
+    return cache.get(label) ?? null;
+  }
+
+  /**
+   * Get options for a dropdown/multiselect attribute by label.
+   * Returns null if attribute not found, empty array if no options.
+   */
+  async getAttributeOptions(label: string): Promise<string[] | null> {
+    const attr = await this.getAttributeByLabel(label);
+    if (!attr) return null;
+    return attr.options ?? [];
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -43,6 +43,7 @@ export class WorkerPlytixClient {
   private token?: PlytixAuthToken;
   private config: Required<PlytixClientConfig>;
   private attributeCache?: Map<string, PlytixAttributeDetail>;
+  private attributeCachePromise?: Promise<Map<string, PlytixAttributeDetail>>;
 
   constructor(config: WorkerClientConfig) {
     if (!config.apiKey || !config.apiPassword) {
@@ -477,27 +478,54 @@ export class WorkerPlytixClient {
   /**
    * Build attribute cache indexed by label.
    * Per-request scope — no TTL needed (stateless worker).
+   * Deduplicates concurrent callers via shared promise.
    */
   private async buildAttributeCache(): Promise<Map<string, PlytixAttributeDetail>> {
     if (this.attributeCache) return this.attributeCache;
+    if (this.attributeCachePromise) return this.attributeCachePromise;
 
+    this.attributeCachePromise = this.doBuildAttributeCache();
+    try {
+      return await this.attributeCachePromise;
+    } finally {
+      this.attributeCachePromise = undefined;
+    }
+  }
+
+  private async doBuildAttributeCache(): Promise<Map<string, PlytixAttributeDetail>> {
     const attrIds = await this.searchAttributeIds();
-    const results = await Promise.allSettled(attrIds.map((id) => this.getAttributeById(id)));
+
+    if (attrIds.length === 0) {
+      throw new PlytixError(
+        'Attribute cache build failed: no attributes found. Check API credentials and account configuration.'
+      );
+    }
+
+    // Fetch in batches to avoid overwhelming Plytix rate limits
+    const BATCH_SIZE = 10;
+    const allResults: PromiseSettledResult<PlytixAttributeDetail | null>[] = [];
+    for (let i = 0; i < attrIds.length; i += BATCH_SIZE) {
+      const batch = attrIds.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.allSettled(
+        batch.map((id) => this.getAttributeById(id))
+      );
+      allResults.push(...batchResults);
+    }
 
     const byLabel = new Map<string, PlytixAttributeDetail>();
     let failures = 0;
-    for (const result of results) {
+    for (const result of allResults) {
       if (result.status === 'fulfilled' && result.value?.label) {
         byLabel.set(result.value.label, result.value);
-      } else if (result.status === 'rejected') {
+      } else {
         failures++;
       }
     }
 
-    // If >20% of fetches failed, don't cache — surface the error
-    if (attrIds.length > 0 && failures > attrIds.length * 0.2) {
+    // If >20% of fetches failed or returned empty, don't cache — surface the error
+    if (failures > attrIds.length * 0.2) {
       throw new PlytixError(
-        `Attribute cache build failed: ${failures}/${attrIds.length} attribute fetches rejected`
+        `Attribute cache build failed: ${failures}/${attrIds.length} attribute fetches failed or returned empty`
       );
     }
 

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -440,10 +440,11 @@ export class WorkerPlytixClient {
    * Paginate all attribute IDs from the v1 search endpoint.
    */
   async searchAttributeIds(pageSize = 100): Promise<string[]> {
+    const MAX_PAGES = 50; // Safety cap — 5,000 attributes max
     const attrIds: string[] = [];
     let page = 1;
 
-    while (true) {
+    while (page <= MAX_PAGES) {
       const result = await this.request<{ id: string }>(
         '/api/v1/attributes/product/search',
         {
@@ -484,10 +485,20 @@ export class WorkerPlytixClient {
     const results = await Promise.allSettled(attrIds.map((id) => this.getAttributeById(id)));
 
     const byLabel = new Map<string, PlytixAttributeDetail>();
+    let failures = 0;
     for (const result of results) {
       if (result.status === 'fulfilled' && result.value?.label) {
         byLabel.set(result.value.label, result.value);
+      } else if (result.status === 'rejected') {
+        failures++;
       }
+    }
+
+    // If >20% of fetches failed, don't cache — surface the error
+    if (attrIds.length > 0 && failures > attrIds.length * 0.2) {
+      throw new PlytixError(
+        `Attribute cache build failed: ${failures}/${attrIds.length} attribute fetches rejected`
+      );
     }
 
     this.attributeCache = byLabel;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -856,6 +856,13 @@ const toolHandlers: Record<string, ToolHandler> = {
     });
     const updated = result.data?.[0];
 
+    if (!updated?.id) {
+      return {
+        content: [{ type: 'text', text: `Attribute write may have failed: no response for ${productId}` }],
+        isError: true,
+      };
+    }
+
     return {
       content: [
         {
@@ -866,7 +873,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               product_id: productId,
               attribute_label: attributeLabel,
               action: 'set',
-              modified: updated?.modified,
+              modified: updated.modified,
             },
             null,
             2
@@ -900,6 +907,13 @@ const toolHandlers: Record<string, ToolHandler> = {
     });
     const updated = result.data?.[0];
 
+    if (!updated?.id) {
+      return {
+        content: [{ type: 'text', text: `Attribute clear may have failed: no response for ${productId}` }],
+        isError: true,
+      };
+    }
+
     return {
       content: [
         {
@@ -910,7 +924,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               product_id: productId,
               attribute_label: attributeLabel,
               action: 'cleared',
-              modified: updated?.modified,
+              modified: updated.modified,
             },
             null,
             2
@@ -1144,6 +1158,13 @@ const toolHandlers: Record<string, ToolHandler> = {
     const result = await client.linkProductCategory(productId, categoryId);
     const linked = result.data?.[0];
 
+    if (!linked?.id) {
+      return {
+        content: [{ type: 'text', text: `Category link failed: no response for product ${productId}, category ${categoryId}` }],
+        isError: true,
+      };
+    }
+
     return {
       content: [
         {
@@ -1152,9 +1173,7 @@ const toolHandlers: Record<string, ToolHandler> = {
             {
               success: true,
               product_id: productId,
-              category: linked
-                ? { id: linked.id, name: linked.name, path: linked.path }
-                : { id: categoryId },
+              category: { id: linked.id, name: linked.name, path: linked.path },
             },
             null,
             2

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -333,7 +333,8 @@ const TOOLS: ToolDefinition[] = [
     name: 'products_update',
     description:
       'Update a product. Partial update - only specified fields are changed. ' +
-      'Set an attribute value to null to clear it.',
+      'Set an attribute value to null to clear it. ' +
+      'NOTE: Does not validate attribute values — use products_set_attribute for validated writes.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,6 +13,7 @@
 import { WorkerPlytixClient } from './worker-client.js';
 import { WorkerPlytixLookup } from './worker-lookup.js';
 import { stripAttributesPrefix } from './utils/attribute-labels.js';
+import { validateAttributeValue } from './utils/validate-attribute.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -230,6 +231,40 @@ const TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'attributes_get',
+    description:
+      'Get full details for a single attribute by its label (snake_case identifier like "head_material"). ' +
+      'Returns type, options (for dropdowns), groups, and other metadata. ' +
+      'Use this to inspect a specific attribute or get its allowed values.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: {
+          type: 'string',
+          description: 'Attribute label (snake_case identifier, e.g., "head_material")',
+        },
+      },
+      required: ['label'],
+    },
+  },
+  {
+    name: 'attributes_get_options',
+    description:
+      'Get the allowed values (options) for a dropdown or multiselect attribute. ' +
+      'Returns an array of valid option strings. ' +
+      'Use this to validate enum values or sync options to external systems.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: {
+          type: 'string',
+          description: 'Attribute label (snake_case identifier, e.g., "head_material")',
+        },
+      },
+      required: ['label'],
+    },
+  },
+  {
     name: 'attributes_filters',
     description: 'Get all available search filters for product queries.',
     inputSchema: {
@@ -263,6 +298,71 @@ const TOOLS: ToolDefinition[] = [
         attribute_label: { type: 'string', description: 'Attribute label (snake_case)' },
       },
       required: ['product_id', 'attribute_label'],
+    },
+  },
+  {
+    name: 'products_create',
+    description:
+      'Create a new product. Only SKU is required. ' +
+      'Cannot create new attributes/categories/assets - must link existing ones by ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sku: { type: 'string', description: 'Product SKU (required, must be unique)' },
+        label: { type: 'string', description: 'Product label/name' },
+        status: { type: 'string', description: 'Product status' },
+        attributes: {
+          type: 'object',
+          description: 'Custom attributes as key-value pairs (use attribute labels as keys)',
+        },
+        category_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Category IDs to link to this product',
+        },
+        asset_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Asset IDs to link to this product',
+        },
+      },
+      required: ['sku'],
+    },
+  },
+  {
+    name: 'products_update',
+    description:
+      'Update a product. Partial update - only specified fields are changed. ' +
+      'Set an attribute value to null to clear it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID to update' },
+        label: { type: 'string', description: 'New product label/name' },
+        status: { type: 'string', description: 'New product status' },
+        attributes: {
+          type: 'object',
+          description: 'Attributes to update (use attribute labels as keys, null to clear)',
+        },
+      },
+      required: ['product_id'],
+    },
+  },
+  {
+    name: 'products_assign_family',
+    description:
+      'Assign a product family to a product. Pass empty string to unassign. ' +
+      'WARNING: Changing family may cause data loss. Cannot assign to variant products.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID' },
+        family_id: {
+          type: 'string',
+          description: 'The family ID to assign (empty string to unassign)',
+        },
+      },
+      required: ['product_id', 'family_id'],
     },
   },
   {
@@ -313,6 +413,30 @@ const TOOLS: ToolDefinition[] = [
         product_id: { type: 'string', description: 'The product ID' },
       },
       required: ['product_id'],
+    },
+  },
+  {
+    name: 'categories_link',
+    description: 'Link an existing category to a product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID' },
+        category_id: { type: 'string', description: 'The category ID to link' },
+      },
+      required: ['product_id', 'category_id'],
+    },
+  },
+  {
+    name: 'categories_unlink',
+    description: 'Remove a category link from a product. The category itself is not deleted.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        product_id: { type: 'string', description: 'The product ID' },
+        category_id: { type: 'string', description: 'The category ID to unlink' },
+      },
+      required: ['product_id', 'category_id'],
     },
   },
   {
@@ -629,6 +753,69 @@ const toolHandlers: Record<string, ToolHandler> = {
     };
   },
 
+  async attributes_get(args, client) {
+    const label = args.label as string;
+    const attr = await client.getAttributeByLabel(label);
+
+    if (!attr) {
+      return {
+        content: [{ type: 'text', text: `Attribute not found: ${label}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              id: attr.id,
+              label: attr.label,
+              name: attr.name,
+              type_class: attr.type_class,
+              options: attr.options ?? [],
+              options_count: attr.options?.length ?? 0,
+              groups: attr.groups ?? [],
+              description: attr.description,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async attributes_get_options(args, client) {
+    const label = args.label as string;
+    const options = await client.getAttributeOptions(label);
+
+    if (options === null) {
+      return {
+        content: [{ type: 'text', text: `Attribute not found: ${label}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              label,
+              options,
+              count: options.length,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
   async products_set_attribute(args, client) {
     const productId = args.product_id as string;
     const attributeLabel = stripAttributesPrefix(args.attribute_label as string);
@@ -644,6 +831,22 @@ const toolHandlers: Record<string, ToolHandler> = {
     if (value === null) {
       return {
         content: [{ type: 'text', text: 'Value cannot be null. Use products_clear_attribute instead.' }],
+        isError: true,
+      };
+    }
+
+    const attribute = await client.getAttributeByLabel(attributeLabel);
+    if (!attribute) {
+      return {
+        content: [{ type: 'text', text: `Attribute not found: ${attributeLabel}` }],
+        isError: true,
+      };
+    }
+
+    const validationError = validateAttributeValue(attribute, value);
+    if (validationError) {
+      return {
+        content: [{ type: 'text', text: validationError }],
         isError: true,
       };
     }
@@ -684,6 +887,14 @@ const toolHandlers: Record<string, ToolHandler> = {
       };
     }
 
+    const attribute = await client.getAttributeByLabel(attributeLabel);
+    if (!attribute) {
+      return {
+        content: [{ type: 'text', text: `Attribute not found: ${attributeLabel}` }],
+        isError: true,
+      };
+    }
+
     const result = await client.updateProduct(productId, {
       attributes: { [attributeLabel]: null },
     });
@@ -700,6 +911,129 @@ const toolHandlers: Record<string, ToolHandler> = {
               attribute_label: attributeLabel,
               action: 'cleared',
               modified: updated?.modified,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async products_create(args, client) {
+    const sku = args.sku as string;
+    const label = args.label as string | undefined;
+    const status = args.status as string | undefined;
+    const attributes = args.attributes as Record<string, unknown> | undefined;
+    const categoryIds = args.category_ids as string[] | undefined;
+    const assetIds = args.asset_ids as string[] | undefined;
+
+    const data: Parameters<typeof client.createProduct>[0] = { sku };
+    if (label !== undefined) data.label = label;
+    if (status !== undefined) data.status = status;
+    if (attributes !== undefined) data.attributes = attributes;
+    if (categoryIds?.length) data.categories = categoryIds.map((id) => ({ id }));
+    if (assetIds?.length) data.assets = assetIds.map((id) => ({ id }));
+
+    const result = await client.createProduct(data);
+    const created = result.data?.[0];
+
+    if (!created?.id) {
+      return {
+        content: [{ type: 'text', text: 'Product creation failed: no ID returned from API' }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              id: created.id,
+              created: created.created,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async products_update(args, client) {
+    const productId = args.product_id as string;
+    const label = args.label as string | undefined;
+    const status = args.status as string | undefined;
+    const attributes = args.attributes as Record<string, unknown> | undefined;
+
+    const data: Parameters<typeof client.updateProduct>[1] = {};
+    if (label !== undefined) data.label = label;
+    if (status !== undefined) data.status = status;
+    if (attributes !== undefined) data.attributes = attributes;
+
+    if (Object.keys(data).length === 0) {
+      return {
+        content: [{ type: 'text', text: 'No fields provided to update' }],
+        isError: true,
+      };
+    }
+
+    const result = await client.updateProduct(productId, data);
+    const updated = result.data?.[0];
+
+    if (!updated?.id) {
+      return {
+        content: [{ type: 'text', text: `Product update failed: no response for ${productId}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              id: updated.id,
+              modified: updated.modified,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async products_assign_family(args, client) {
+    const productId = args.product_id as string;
+    const familyId = args.family_id as string;
+
+    const result = await client.assignProductFamily(productId, familyId);
+    const updated = result.data?.[0];
+
+    if (!updated?.id) {
+      return {
+        content: [{ type: 'text', text: `Family assignment failed: no response for ${productId}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              id: updated.id,
+              family_id: familyId || null,
+              action: familyId ? 'assigned' : 'unassigned',
+              modified: updated.modified,
             },
             null,
             2
@@ -794,6 +1128,58 @@ const toolHandlers: Record<string, ToolHandler> = {
             {
               categories: result.data,
               count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async categories_link(args, client) {
+    const productId = args.product_id as string;
+    const categoryId = args.category_id as string;
+
+    const result = await client.linkProductCategory(productId, categoryId);
+    const linked = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              category: linked
+                ? { id: linked.id, name: linked.name, path: linked.path }
+                : { id: categoryId },
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async categories_unlink(args, client) {
+    const productId = args.product_id as string;
+    const categoryId = args.category_id as string;
+
+    await client.unlinkProductCategory(productId, categoryId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              product_id: productId,
+              category_id: categoryId,
+              action: 'unlinked',
             },
             null,
             2


### PR DESCRIPTION
## Summary
- Adds 7 missing tools to the Cloudflare Worker MCP server: `products_create`, `products_update`, `products_assign_family`, `attributes_get`, `attributes_get_options`, `categories_link`, `categories_unlink`
- Adds attribute validation (existence check + dropdown/multiselect enum checks) to worker's `set_attribute` and `clear_attribute` handlers, matching stdio behavior
- Adds 4 client methods + full attribute cache (paginated upfront, per-request scope) to `WorkerPlytixClient`
- Extracts `validateAttributeValue` to shared util (`src/utils/validate-attribute.ts`) used by both runtimes

Worker now has 26 tools matching stdio parity (minus 3 intentionally excluded stateless utilities: `identifier_detect`, `identifier_normalize`, `match_score`).

## Validation
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [x] Unit tests: 33/33 passing
- [x] MCP handshake test passes (26 tools listed)
- [ ] Automated review agents
- [ ] Bugbot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ded3a64573ab672bd9275e2c8e066d4b0d084c30. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->