### PR TITLE
feat: expand Plytix MCP tool surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,20 +26,22 @@ npm run typecheck    # Type check without building
 src/
   index.ts              # MCP server entry point
   client.ts             # Enhanced Plytix API client
+  worker-client.ts      # Request-scoped Plytix client for the Cloudflare Worker
   types.ts              # TypeScript types for Plytix API
+  worker.ts             # Cloudflare Worker MCP entry point
   lookup/
     identifier.ts       # Identifier type detection (ID, SKU, MPN, GTIN, label)
     lookup.ts           # Smart product lookup with staged search
     index.ts            # Barrel export
   tools/
     products.ts         # Product tools (lookup, get, search, find, writes)
-    families.ts         # Family tools (list, get)
-    attributes.ts       # Attribute metadata tools
+    families.ts         # Family tools (list, get, create, attribute membership)
+    attributes.ts       # Attribute metadata + filter discovery tools
     product-attributes.ts # Atomic product attribute write tools
-    assets.ts           # Asset list/link/unlink tools
-    categories.ts       # Category list/link/unlink tools
-    variants.ts         # Variant list/resync tools
-    relationships.ts    # Product relationship write tools
+    assets.ts           # Asset get/search/update + product asset link tools
+    categories.ts       # Category search + product category link tools
+    variants.ts         # Variant lifecycle tools
+    relationships.ts    # Relationship discovery + product relationship write tools
   supplyline/           # Supplyline-specific customizations
     index.ts            # Supplyline tool registration
 ```
@@ -50,37 +52,57 @@ src/
 
 | Tool | Description |
 |------|-------------|
-| `products.lookup` | Smart lookup by any identifier (auto-detects type) |
-| `products.get` | Get single product by ID (includes `overwritten_attributes`) |
-| `products.search` | Advanced search with filters, pagination, sorting |
-| `products.find` | Multi-criteria search (SKU, MPN, GTIN, label, fuzzy) |
-| `families.list` | List/search product families |
-| `families.get` | Get single family with linked attributes |
-| `attributes.list` | List all attributes (system + custom) |
-| `attributes.get` | Get full details for a single attribute by label |
-| `attributes.get_options` | Get allowed values for a dropdown/multiselect attribute |
-| `attributes.filters` | Get available search filters |
-| `assets.list` | List assets linked to a product |
-| `categories.list` | List categories linked to a product |
-| `variants.list` | List variants for a product |
+| `products_lookup` | Smart lookup by any identifier (auto-detects type) |
+| `products_get` | Get a single product by ID (includes `overwritten_attributes`) |
+| `products_search` | Advanced product search with filters, pagination, and sorting |
+| `products_find` | Multi-criteria search (SKU, MPN, GTIN, label, fuzzy) |
+| `families_list` | List or search product families |
+| `families_get` | Get one product family |
+| `families_list_attributes` | List attributes directly linked to a family |
+| `families_list_all_attributes` | List direct + inherited family attributes |
+| `attributes_list` | List all product attributes (system + custom) |
+| `attributes_get` | Get full details for a single attribute by label |
+| `attributes_get_options` | Get allowed values for a dropdown/multiselect attribute |
+| `attributes_filters` | Deprecated alias for product filter discovery |
+| `products_filters` | Get product search filter metadata |
+| `assets_filters` | Get asset search filter metadata |
+| `relationships_filters` | Get relationship search filter metadata |
+| `assets_get` | Get a single asset by ID |
+| `assets_search` | Search account assets |
+| `assets_list` | List assets linked to a product |
+| `categories_search` | Search existing product categories |
+| `categories_list` | List categories linked to a product |
+| `variants_list` | List variants for a product |
+| `relationships_get` | Get a relationship definition |
+| `relationships_search` | Search relationship definitions |
+| `identifier_detect` | Detect identifier type from format |
+| `identifier_normalize` | Normalize identifier formatting for comparison |
+| `match_score` | Score how well an identifier matches product data |
 
 ### Write Operations
 
 | Tool | Description |
 |------|-------------|
-| `products.create` | Create a new product (SKU required) |
-| `products.update` | Update product attributes (PATCH - partial update) |
-| `products.assign_family` | Assign/unassign family (⚠️ may cause data loss) |
-| `products.set_attribute` | Set one product attribute atomically |
-| `products.clear_attribute` | Clear one product attribute atomically |
-| `assets.link` | Link existing asset to product |
-| `assets.unlink` | Unlink asset from product |
-| `categories.link` | Link existing category to product |
-| `categories.unlink` | Unlink category from product |
-| `variants.resync` | Restore variant attributes to inherit from parent |
-| `relationships.link_product` | Link one related product row |
-| `relationships.unlink_product` | Unlink one related product row |
-| `relationships.set_quantity` | Update quantity for one related product row |
+| `products_create` | Create a new product (SKU required) |
+| `products_update` | Update product fields and attributes (PATCH) |
+| `products_assign_family` | Assign or unassign family (may cause data loss) |
+| `products_set_attribute` | Set one product attribute atomically |
+| `products_clear_attribute` | Clear one product attribute atomically |
+| `families_create` | Create a new product family |
+| `families_link_attribute` | Link one or more attributes to a family |
+| `families_unlink_attribute` | Unlink one or more attributes from a family |
+| `assets_update` | Update asset metadata (`filename`, `categories` only) |
+| `assets_link` | Link an existing asset to a product |
+| `assets_unlink` | Unlink an asset from a product |
+| `categories_link` | Link an existing category to a product |
+| `categories_unlink` | Unlink an existing category from a product |
+| `variants_create` | Create a new variant beneath a parent product |
+| `variants_link` | Convert an existing product into a variant |
+| `variants_unlink` | Detach a variant without deleting the product |
+| `variants_resync` | Restore variant attributes to inherit from parent |
+| `relationships_link_product` | Link one related product row |
+| `relationships_unlink_product` | Unlink one related product row |
+| `relationships_set_quantity` | Update quantity for one related product row |
 
 ## Smart Lookup System
 
@@ -138,8 +160,8 @@ Optional:
 - `name` = human-readable name (e.g., "Head Material")
 
 **API versions:**
-- Products, Assets, Variants, Categories: v2 API (`/api/v2/...`)
-- Families, Filters: v1 API (`/api/v1/...`)
+- Product reads/writes, product-linked assets/categories, relationship mutations, and most variant operations use v2 (`/api/v2/...`)
+- Account-level assets, category discovery, relationship definitions, families, filters, and attribute metadata use v1 (`/api/v1/...`)
 
 **Attribute limits:**
 - v2 search: max 50 attributes
@@ -171,12 +193,12 @@ Related fields:
 
 ## Session Notes
 
-_Last updated: 2025-01-22_
+_Last updated: 2026-03-11_
 
 ### Recent Changes
-- Added write tools: `products.create`, `products.update`, `products.assign_family`
-- Added category tools: `categories.link`, `categories.unlink`
-- Client methods for all write operations
+- Added variant lifecycle tools: `variants_create`, `variants_link`, `variants_unlink`
+- Added asset read/search/update tools and split filter discovery by resource
+- Added category search, relationship discovery, and expanded family operations
 
 ### v0.2.0 (2025-01-16)
 - Ported smart lookup system from archived codebase

--- a/docs/solutions/api-quirks/plytix-api.md
+++ b/docs/solutions/api-quirks/plytix-api.md
@@ -1,0 +1,460 @@
+# Plytix API Reference for Agents
+
+Compressed reference derived from the supplied March 11, 2026 scrape.
+
+## 1. Base URLs
+
+- Auth: `https://auth.plytix.com/auth/api/get-token`
+- API v1: `https://pim.plytix.com/api/v1`
+- API v2 beta: `https://pim.plytix.com/api/v2`
+
+## 2. Auth
+
+Get a bearer token with:
+
+```json
+POST https://auth.plytix.com/auth/api/get-token
+{
+  "api_key": "...",
+  "api_password": "..."
+}
+```
+
+Token comes back at:
+
+```json
+data[0].access_token
+```
+
+Rules:
+
+- token TTL is 15 minutes
+- send `Authorization: Bearer <token>`
+- send `Content-Type: application/json`
+
+## 3. Universal response format
+
+Success:
+
+```json
+{"data":[...], "pagination": {...}}
+```
+
+Error:
+
+```json
+{"error":{"msg":"...", "errors":[{"field":"...","msg":"..."}]}}
+```
+
+## 4. Search DSL
+
+`filters` is OR-of-ANDs:
+
+- outer array = `OR`
+- each inner array = `AND`
+- each filter = `{field, operator, value}`
+
+Example:
+
+```json
+{
+  "filters": [
+    [
+      {"field":"status","operator":"eq","value":"Completed"},
+      {"field":"attributes.volume_liters","operator":"gt","value":3}
+    ],
+    [
+      {"field":"sku","operator":"like","value":"mug"}
+    ]
+  ]
+}
+```
+
+Common operators:
+
+- `exists`, `!exists`
+- `eq`, `!eq`
+- `like`
+- `in`, `!in`
+- `gt`, `gte`, `lt`, `lte`
+- `text_search`
+
+Pagination:
+
+```json
+{
+  "pagination": {
+    "page": 1,
+    "page_size": 25,
+    "order": "-sku"
+  }
+}
+```
+
+Rules:
+
+- default page size is 25
+- max `page_size` is usually 100
+- `order` format is `field` or `-field`
+
+## 5. Version choice
+
+Use `v2` for product operations unless you specifically need an older v1 behavior.
+
+Use `v1` for:
+
+- auth
+- accounts search
+- assets resource
+- filter metadata
+- file/product category resources
+- product attributes
+- product families in this scrape
+
+Use `v2 beta` for:
+
+- products
+- product-linked assets
+- product-linked categories
+- variants
+- product relationship mutations
+
+## 6. Product search rules
+
+Main endpoint:
+
+- `POST /api/v2/products/search`
+
+Important rules:
+
+- user attributes must be requested as `attributes.<label>`
+- relationship columns must be requested as `relationships.<label>`
+- discover valid labels/operators with `GET /api/v1/filters/product`
+- product search allows up to 50 requested attributes/properties plus `id` and `sku`
+- if more than 10,000 results match and `pagination.order` is set, expect `428`
+- only one relationship can be selected in filters
+
+Example:
+
+```json
+{
+  "filters": [
+    [
+      {"field":"status","operator":"eq","value":"Completed"},
+      {"field":"attributes.volume_liters","operator":"gt","value":3}
+    ]
+  ],
+  "attributes": [
+    "label",
+    "status",
+    "modified",
+    "attributes.volume_liters"
+  ],
+  "pagination": {
+    "order": "attributes.volume_liters",
+    "page": 1,
+    "page_size": 25
+  }
+}
+```
+
+## 7. Product hydration pattern
+
+Recommended flow:
+
+1. Search products with `POST /api/v2/products/search`
+2. Get a specific product with `GET /api/v2/products/:product_id`
+3. Hydrate linked assets/categories separately if needed:
+   - `GET /api/v2/products/:product_id/assets`
+   - `GET /api/v2/products/:product_id/categories`
+
+Reason:
+
+- v2 product/search responses do not expand linked media/categories into full objects
+- they return ids or id-like arrays instead
+
+## 8. Core product endpoints
+
+### v2 products
+
+- `POST /api/v2/products`
+- `GET /api/v2/products/:product_id`
+- `PATCH /api/v2/products/:product_id`
+- `DELETE /api/v2/products/:product_id`
+- `POST /api/v2/products/:product_id/family`
+
+Behavior:
+
+- create and patch return id + timestamps/audit metadata, not full product bodies
+- deleting a parent product also deletes its variants unless you unlink them first
+- assigning/changing family can cause data loss
+- family cannot be assigned to variant products
+
+Minimal create:
+
+```json
+{
+  "sku": "unique-sku"
+}
+```
+
+## 9. Assets
+
+### Account-level assets are v1
+
+- `POST /api/v1/assets`
+- `POST /api/v1/assets/search`
+- `GET /api/v1/assets/:asset_id`
+- `PATCH /api/v1/assets/:asset_id`
+- `DELETE /api/v1/assets/:asset_id`
+- `PUT /api/v1/assets/:asset_id/content`
+
+Upload modes:
+
+1. by public URL
+2. by raw base64 content
+
+Notes:
+
+- base64 upload should not include the `data:image/...;base64,` prefix
+- `PUT /content` uses `multipart/form-data`
+
+### Product-linked asset endpoints
+
+- `GET /api/v2/products/:product_id/assets`
+- `POST /api/v2/products/:product_id/assets`
+- `DELETE /api/v2/products/:product_id/assets/:asset_id`
+
+Link body:
+
+```json
+{
+  "id": "asset_id",
+  "attribute_label": "thumbnail"
+}
+```
+
+Rules:
+
+- links existing assets only
+- `thumbnail` and single-media attrs are replace semantics
+- media-gallery attrs append
+- limit: 300 linked assets per product
+
+## 10. Categories
+
+### Category resources are v1
+
+File categories:
+
+- `POST /api/v1/categories/file`
+- `POST /api/v1/categories/file/:category_id`
+- `PATCH /api/v1/categories/file/:category_id`
+- `PATCH /api/v1/categories/file/root`
+- `DELETE /api/v1/categories/file/:category_id`
+- `POST /api/v1/categories/file/search`
+
+Product categories:
+
+- `POST /api/v1/categories/product`
+- `POST /api/v1/categories/product/:category_id`
+- `PATCH /api/v1/categories/product/:category_id`
+- `PATCH /api/v1/categories/product/root`
+- `DELETE /api/v1/categories/product/:category_id`
+- `POST /api/v1/categories/product/search`
+
+Important rules:
+
+- deleting a category deletes its subtree
+- move children first if you need to preserve them
+- `parent_id` and `sort_children` cannot be combined in one patch
+- sorting child categories requires the full ordered child list
+
+### Product-linked category endpoints
+
+- `GET /api/v2/products/:product_id/categories`
+- `POST /api/v2/products/:product_id/categories`
+- `DELETE /api/v2/products/:product_id/categories/:category_id`
+
+Link body:
+
+```json
+{"id":"category_id"}
+```
+
+## 11. Variants
+
+### v2 variant endpoints
+
+- `POST /api/v2/products/:product_id/variant/:variant_id`
+- `DELETE /api/v2/products/:parent_product_id/variant/:variant_id`
+- `POST /api/v2/products/:parent_product_id/variants`
+- `POST /api/v2/products/:parent_product_id/variants/resync`
+
+Rules:
+
+- linking/unlinking variants can cause data loss
+- products must share family or both be unassigned when linking
+- v2 create-variant body is direct, not nested under `variant`
+
+Create variant:
+
+```json
+{
+  "sku": "new-variant-sku",
+  "label": "optional label",
+  "attributes": {
+    "some_attribute_label": "value"
+  }
+}
+```
+
+Resync:
+
+```json
+{
+  "attribute_labels": ["attr_1", "attr_2"],
+  "variant_ids": ["variant_id_1", "variant_id_2"]
+}
+```
+
+## 12. Relationships
+
+### v2 product relationship mutations
+
+- `POST /api/v2/products/:product_id/relationships/:relationship_id`
+- `PATCH /api/v2/products/:product_id/relationships/:relationship_id`
+- `DELETE /api/v2/products/:product_id/relationships/:relationship_id`
+
+Assign/update body:
+
+```json
+{
+  "product_relationships": [
+    {"product_id":"related_product_id","quantity":1}
+  ]
+}
+```
+
+Delete body:
+
+```json
+{
+  "product_relationships": ["related_product_id_1", "related_product_id_2"]
+}
+```
+
+Important v2 behavior:
+
+- nonexistent product ids are silently ignored
+- already-linked ids are silently ignored on add
+- unlinked ids are silently ignored on delete/patch
+- these endpoints favor empty-success over strict validation
+
+### Relationship filters in product search
+
+Use `relationship_filters` alongside normal `filters`.
+
+Shape:
+
+```json
+{
+  "relationship_id": "rel_id",
+  "operator": "exists",
+  "product_ids": [
+    {
+      "id": "product_id",
+      "qty_operator": "gt",
+      "value": [2]
+    }
+  ]
+}
+```
+
+`qty_operator` values shown in scrape:
+
+- `exists`
+- `eq`
+- `in`
+- `gt`
+- `gte`
+- `lt`
+- `lte`
+- `bte`
+- `last_days`
+
+## 13. Filter discovery endpoints
+
+Use these to build valid searches:
+
+- `GET /api/v1/filters/asset`
+- `GET /api/v1/filters/product`
+- `GET /api/v1/filters/relationships`
+
+Returned filter metadata includes:
+
+- `key`
+- `operators`
+- `options` when enum-like
+- `filter_type`
+
+## 14. Product attribute metadata
+
+Product attributes are still documented under v1.
+
+- `GET /api/v1/attributes/product/:product_attribute_id`
+- `PATCH /api/v1/attributes/product/:product_attribute_id`
+
+Common type classes:
+
+- `TextAttribute`
+- `MultilineAttribute`
+- `HtmlAttribute`
+- `IntAttribute`
+- `DecimalAttribute`
+- `DropdownAttribute`
+- `MultiSelectAttribute`
+- `DateAttribute`
+- `UrlAttribute`
+- `BooleanAttribute`
+- `MediaAttribute`
+- `MediaGalleryAttribute`
+- `CompletenessAttribute`
+
+Patchable fields:
+
+- all attrs: `name`, `description`
+- dropdown/multiselect: `options` replaces full set
+- completeness: `attributes`
+
+## 15. Accounts endpoints
+
+- `POST /api/v1/accounts/memberships/search`
+- `POST /api/v1/accounts/api-credentials/search`
+
+Notes:
+
+- sorting not supported
+- if `attributes` is omitted, all fields are returned
+
+## 16. High-value gotchas
+
+- Token expires after 15 minutes.
+- Product search uses attribute labels, not display names.
+- Prefix custom product fields with `attributes.`.
+- Use v2 for product CRUD/search, but v1 for filter metadata and most catalog metadata resources.
+- v2 product GET/search does not expand linked assets/categories/media; hydrate separately.
+- `page_size > 100` typically fails with `422`.
+- Ordered searches over very large result sets can fail with `428`.
+- Category delete is recursive.
+- Linking/unlinking variants can destroy inherited data shape.
+- v2 relationship mutations silently ignore many bad ids instead of erroring.
+
+## 17. Minimal working sequence
+
+1. Authenticate.
+2. Discover product labels/operators with `GET /api/v1/filters/product`.
+3. Search via `POST /api/v2/products/search`.
+4. Fetch a product via `GET /api/v2/products/:product_id`.
+5. Hydrate assets/categories with nested v2 endpoints if needed.
+

--- a/docs/solutions/api-quirks/plytix-api_2026-03-11.md
+++ b/docs/solutions/api-quirks/plytix-api_2026-03-11.md
@@ -1,0 +1,1319 @@
+# Plytix API Snapshot
+
+Cleaned from the supplied `https://apidocs.plytix.com llms-full.txt` scrape on March 11, 2026.
+
+This file removes scrape noise, duplicated examples, and obvious UI artifacts while preserving the API contract described in the supplied snapshot.
+
+## Scope and normalization
+
+- This is a cleaned snapshot of the supplied scrape, not a fresh crawl.
+- When the scrape contradicted itself, this document prefers:
+  1. endpoint-specific detail over generic overview text
+  2. prose descriptions over malformed example requests
+  3. stable request/response shapes over example status labels
+- Some resource families appear only as summary tables in the supplied scrape. Those are included as inventory items and marked when details were not expanded.
+
+## Base URLs
+
+- Auth: `https://auth.plytix.com`
+- API v1: `https://pim.plytix.com/api/v1`
+- API v2 beta: `https://pim.plytix.com/api/v2`
+
+## Authentication
+
+- All API requests use bearer-token auth.
+- Obtain a token with:
+  - `POST https://auth.plytix.com/auth/api/get-token`
+- Request body:
+
+```json
+{
+  "api_key": "your.api.key",
+  "api_password": "your.secret.api.password"
+}
+```
+
+- Success response:
+
+```json
+{
+  "data": [
+    {
+      "access_token": "..."
+    }
+  ]
+}
+```
+
+- Token lifetime: 15 minutes.
+- Use on subsequent requests:
+
+```http
+Authorization: Bearer <token>
+Content-Type: application/json
+Accept: application/json
+```
+
+## Global behavior
+
+### Rate limits
+
+- Rate limiting is plan-based.
+- Limits are enforced per client/account plan.
+- The scrape describes limits as:
+  - requests per 10 seconds
+  - requests per hour
+- Exceeded limits return `429 Too Many Requests`.
+
+### Response envelope
+
+Successful responses are wrapped in `data`.
+
+```json
+{
+  "data": []
+}
+```
+
+Optional fields:
+
+- `pagination`: present on search endpoints
+- `attributes`: sometimes present when relevant to the operation
+
+### Error envelope
+
+Errors are wrapped in `error`.
+
+```json
+{
+  "error": {
+    "msg": "product data validation failed",
+    "errors": [
+      {
+        "field": "some_field",
+        "msg": "explanation"
+      }
+    ]
+  }
+}
+```
+
+### Common status codes
+
+The scrape documents these statuses:
+
+- `200 OK`
+- `201 Created`
+- `202 Accepted`
+- `204 No Content`
+- `400 Bad Request`
+- `401 Auth Failed`
+- `403 Forbidden`
+- `404 Not Found`
+- `405 Method Not Allowed`
+- `409 Conflict`
+- `422 Unprocessable Entity`
+- `428 Precondition Required`
+- `429 Too Many Requests`
+- `500 Server Error`
+
+### Deprecation header
+
+- `X-Plytix-Deprecation`: returned when an endpoint is being deprecated soon.
+
+## Search and filter model
+
+The same basic search shape appears across assets, categories, products, memberships, API credentials, and other searchable resources.
+
+### Filter structure
+
+- A simple filter is one condition:
+
+```json
+{"field": "stock", "operator": "gt", "value": 10}
+```
+
+- A compound filter is an array of simple filters combined with `AND`:
+
+```json
+[
+  {"field": "stock", "operator": "gt", "value": 10},
+  {"field": "vendor", "operator": "like", "value": "ACME"}
+]
+```
+
+- A full `filters` array is an array of compound filters combined with `OR`:
+
+```json
+[
+  [
+    {"field": "stock", "operator": "gt", "value": 10},
+    {"field": "vendor", "operator": "like", "value": "ACME"}
+  ],
+  [
+    {"field": "customer", "operator": "eq", "value": "Wile E. Coyote"}
+  ]
+]
+```
+
+### Standard operators
+
+- `exists`
+- `!exists`
+- `eq`
+- `!eq`
+- `like`
+- `in`
+- `!in`
+- `gt`
+- `gte`
+- `lt`
+- `lte`
+- `text_search`
+
+Notes from the scrape:
+
+- Text comparisons for `eq`/`!eq` ignore case.
+- `Dropdown` and `MultiSelect` values are case-sensitive for `in`/`!in`.
+- `text_search` takes an array of field names in `field`.
+
+### Pagination
+
+```json
+{
+  "pagination": {
+    "page": 1,
+    "page_size": 25,
+    "order": "-sku"
+  }
+}
+```
+
+- `order` format: `[optional -][attribute_label]`
+- default page: `1`
+- default page size: `25`
+- many endpoints cap `page_size` at `100`
+
+### Attribute selection
+
+- Search endpoints often return only a subset of fields unless `attributes` is specified.
+- Product search uses attribute labels, not human-readable names.
+- User product attributes must be prefixed with `attributes.`
+- Relationship response columns must be prefixed with `relationships.`
+
+### Important limit note
+
+The scrape is inconsistent on attribute limits:
+
+- a generic overview section says search results can return up to `20` attributes
+- the later product-search sections explicitly say product searches allow up to `50` requested attributes/properties, plus `id` and `sku`
+
+Use the endpoint-specific product-search rule for product search requests.
+
+## Version map from the supplied scrape
+
+### v1 resources explicitly documented in detail
+
+- auth token
+- accounts search
+- assets
+- filter metadata
+- file categories
+- product categories
+- products
+- nested product assets
+- nested product categories
+- variants
+- product relationship operations
+- product attributes
+
+### v1 resources listed in summary only
+
+- relationships root resource
+- product families
+- product attribute groups
+
+### v2 beta resources explicitly documented in detail
+
+- products
+- nested product assets
+- nested product categories
+- variants
+- product relationship operations
+- family assignment
+
+## Endpoint inventory
+
+### Auth
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `https://auth.plytix.com/auth/api/get-token` | Exchange API key/password for bearer token |
+
+### Accounts v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/accounts/memberships/search` | Search memberships |
+| `POST` | `/accounts/api-credentials/search` | Search API credentials |
+
+### Assets v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/assets` | Upload asset by URL or base64 content |
+| `POST` | `/assets/search` | Search assets |
+| `GET` | `/assets/:asset_id` | Get asset |
+| `PATCH` | `/assets/:asset_id` | Rename asset or update categories |
+| `DELETE` | `/assets/:asset_id` | Delete asset |
+| `PUT` | `/assets/:asset_id/content` | Replace asset file content |
+
+### Filters v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/filters/asset` | Asset filter definitions |
+| `GET` | `/filters/product` | Product filter definitions |
+| `GET` | `/filters/relationships` | Relationship filter definitions |
+
+### File categories v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/categories/file` | Create root file category |
+| `POST` | `/categories/file/:category_id` | Create file subcategory |
+| `PATCH` | `/categories/file/:category_id` | Rename, move, or sort children |
+| `PATCH` | `/categories/file/root` | Sort root file categories |
+| `DELETE` | `/categories/file/:category_id` | Delete category tree |
+| `POST` | `/categories/file/search` | Search file categories |
+
+### Product categories v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/categories/product` | Create root product category |
+| `POST` | `/categories/product/:category_id` | Create product subcategory |
+| `PATCH` | `/categories/product/:category_id` | Rename, move, or sort children |
+| `PATCH` | `/categories/product/root` | Sort root product categories |
+| `DELETE` | `/categories/product/:category_id` | Delete category tree |
+| `POST` | `/categories/product/search` | Search product categories |
+
+### Products v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/products` | Create product |
+| `POST` | `/products/search` | Search products |
+| `GET` | `/products/:product_id` | Get product |
+| `PATCH` | `/products/:product_id` | Patch product |
+| `DELETE` | `/products/:product_id` | Delete product |
+| `POST` | `/products/:product_id/family` | Assign or unassign family |
+
+### Product-linked assets v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/products/:product_id/assets` | List linked assets |
+| `POST` | `/products/:product_id/assets` | Link existing asset to thumbnail/media/media-gallery |
+| `GET` | `/products/:product_id/assets/:asset_id` | Get one linked asset |
+| `DELETE` | `/products/:product_id/assets/:asset_id` | Unlink asset |
+
+### Product-linked categories v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/products/:product_id/categories` | List linked categories |
+| `POST` | `/products/:product_id/categories` | Link existing category |
+| `GET` | `/products/:product_id/categories/:category_id` | Get one linked category |
+| `DELETE` | `/products/:product_id/categories/:category_id` | Unlink category |
+
+### Variants v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/products/:product_id/variants` | List variants of a parent product |
+| `POST` | `/products/:parent_product_id/variants` | Create a variant under parent |
+| `POST` | `/products/:product_id/variant/:variant_id` | Link an existing single product as variant |
+| `DELETE` | `/products/:parent_product_id/variant/:variant_id` | Unlink variant from parent |
+| `POST` | `/products/:parent_product_id/variants/resync` | Reset variant values from parent for given labels |
+
+### Product relationship operations v1
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/products/:product_id/relationships/:relationship_id` | Add or update related products |
+| `POST` | `/products/:product_id/relationships/:relationship_id/unlink` | Remove related products; scrape is inconsistent here |
+| `PATCH` | `/products/:product_id/relationships/:relationship_id/product/:related_product_id` | Update quantity |
+
+### Products v2 beta
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/products` | Create product; returns id + audit metadata |
+| `POST` | `/products/search` | Search products; linked media/categories are not expanded |
+| `GET` | `/products/:product_id` | Get product; linked assets/categories/media are ids |
+| `PATCH` | `/products/:product_id` | Patch product; returns id + audit metadata |
+| `DELETE` | `/products/:product_id` | Delete product |
+| `POST` | `/products/:product_id/family` | Assign or unassign family |
+
+### Product-linked assets v2 beta
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/products/:product_id/assets` | List linked assets |
+| `POST` | `/products/:product_id/assets` | Link existing asset to media attr |
+| `DELETE` | `/products/:product_id/assets/:asset_id` | Unlink asset |
+
+### Product-linked categories v2 beta
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/products/:product_id/categories` | List linked categories |
+| `POST` | `/products/:product_id/categories` | Link category |
+| `DELETE` | `/products/:product_id/categories/:category_id` | Unlink category |
+
+### Variants v2 beta
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/products/:product_id/variant/:variant_id` | Link existing product as variant |
+| `DELETE` | `/products/:parent_product_id/variant/:variant_id` | Unlink variant |
+| `POST` | `/products/:parent_product_id/variants` | Create variant; returns new id + audit metadata |
+| `POST` | `/products/:parent_product_id/variants/resync` | Resync parent-level attributes |
+
+### Product relationship operations v2 beta
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `POST` | `/products/:product_id/relationships/:relationship_id` | Add related products; silently ignores bad/duplicate ids |
+| `DELETE` | `/products/:product_id/relationships/:relationship_id` | Remove related products; silently ignores bad/unlinked ids |
+| `PATCH` | `/products/:product_id/relationships/:relationship_id` | Update quantities; silently ignores bad/unlinked ids |
+
+### Summary-only resources listed by the scrape
+
+These were listed in the supplied resource summary but not expanded later in the supplied text.
+
+#### Relationships root v1
+
+| Method | Path |
+| --- | --- |
+| `POST` | `/relationships` |
+| `GET` | `/relationships/:id` |
+| `PATCH` | `/relationships/:id` |
+| `DELETE` | `/relationships/:id` |
+| `POST` | `/relationships/search` |
+
+#### Product families v1
+
+| Method | Path |
+| --- | --- |
+| `POST` | `/product_families` |
+| `GET` | `/product_families/:id` |
+| `PATCH` | `/product_families/:id` |
+| `DELETE` | `/product_families/:id` |
+| `POST` | `/product_families/search` |
+| `POST` | `/product_families/:id/attributes/link` |
+| `POST` | `/product_families/:id/attributes/unlink` |
+| `GET` | `/product_families/:id/attributes` |
+| `GET` | `/product_families/:id/all_attributes` |
+
+## Accounts v1
+
+### `POST /accounts/memberships/search`
+
+Searchable fields:
+
+- `legacy_id`
+- `role` (`ADMIN`, `OWNER`, `USER`)
+- `email`
+- `username`
+- `name`
+- `last_name`
+
+Notes:
+
+- sorting is not supported
+- if `attributes` is omitted, all fields are returned
+
+### `POST /accounts/api-credentials/search`
+
+Searchable fields:
+
+- `legacy_id`
+- `role` (`ADMIN`, `OWNER`, `USER`)
+- `name`
+
+Notes:
+
+- sorting is not supported
+- if `attributes` is omitted, all fields are returned
+
+## Assets v1
+
+### Asset fields in the scrape
+
+- `assigned`
+- `categories`
+- `content_type`
+- `created`
+- `extension`
+- `filename`
+- `file_size`
+- `file_type`
+- `has_custom_thumb`
+- `id`
+- `modified`
+- `n_catalogs`
+- `n_products`
+- `status`
+- `thumbnail`
+- `type`
+- `url`
+
+### Asset type groups
+
+- `IMAGES`
+- `FEED_FILES`
+- `COMPRESSED`
+- `REPORTS`
+- `TEXTS`
+- `SOUNDS`
+- `VIDEOS`
+- `OTHER`
+
+### `POST /assets`
+
+Two upload modes are documented:
+
+1. By URL
+
+```json
+{
+  "filename": "kettle_blue.jpg",
+  "url": "https://public.example.com/file.jpg"
+}
+```
+
+2. By base64 content
+
+```json
+{
+  "filename": "kettle_red.jpg",
+  "content": "<base64-bytes-only>"
+}
+```
+
+Rules:
+
+- URL must be publicly accessible.
+- File type must be supported.
+- If uploading by `content`, the scrape says the content must be raw base64 only; strip any `data:image/...;base64,` prefix.
+
+### `GET /assets/:asset_id`
+
+- Returns one asset in `data[0]`.
+
+### `PATCH /assets/:asset_id`
+
+Supported fields:
+
+- `filename`
+  - extension changes are not allowed
+- `categories`
+  - array of `{ "id": "<category_id>" }`
+
+### `DELETE /assets/:asset_id`
+
+- Deletes the asset.
+- Success is `204 No Content`.
+
+### `PUT /assets/:asset_id/content`
+
+- Replaces the underlying file contents.
+- Content type is `multipart/form-data`.
+- Expected form field: `file`.
+- The scrape shows `202 Accepted`.
+
+### `POST /assets/search`
+
+Notes:
+
+- search uses the standard search DSL
+- the scrape says searches return `428` if filtered results exceed `10000` assets and `pagination.order` is set
+
+## Filters v1
+
+These endpoints return the authoritative filter definitions for a resource.
+
+Returned objects contain:
+
+- `key`: request field name to use in filters
+- `operators`: allowed operators
+- `options`: enum-like allowed values when relevant
+- `filter_type`: descriptive type
+
+### `GET /filters/asset`
+
+Documented characteristics:
+
+- returns current asset filter definitions
+- does not support `text_search`
+
+Common asset filter keys shown in the scrape:
+
+- `status`
+- `file_type`
+- `assigned`
+- `file_size`
+- `id`
+- `categories`
+- `extension`
+- `created`
+- `modified`
+- `filename`
+
+### `GET /filters/product`
+
+This is the key discovery endpoint for product search construction.
+
+System product keys shown in the scrape:
+
+- `created`
+- `modified`
+- `sku`
+- `gtin`
+- `label`
+- `status`
+- `categories`
+- `static_lists`
+- `assets`
+- `images`
+- `thumbnail`
+- `product_level`
+
+Properties shown in the scrape:
+
+- `_is_variation`
+- `_has_variations`
+
+Custom product attributes are returned prefixed with `attributes.`, for example:
+
+- `attributes.color`
+- `attributes.description`
+
+### `GET /filters/relationships`
+
+Common keys shown in the scrape:
+
+- `label`
+- `name`
+- `created`
+- `symmetrical`
+- `id`
+- `modified`
+
+## Categories v1
+
+Both file and product categories share the same shape and operational model.
+
+### Category fields
+
+- `id`
+- `modified`
+- `n_children`
+- `name`
+- `order`
+- `parents_ids`
+- `path`
+- `slug`
+
+### Create root category
+
+- `POST /categories/file`
+- `POST /categories/product`
+
+Body:
+
+```json
+{
+  "name": "Category Name"
+}
+```
+
+### Create subcategory
+
+- `POST /categories/file/:category_id`
+- `POST /categories/product/:category_id`
+
+Body:
+
+```json
+{
+  "name": "Subcategory Name"
+}
+```
+
+### Update category
+
+- `PATCH /categories/file/:category_id`
+- `PATCH /categories/product/:category_id`
+
+Supported patch properties:
+
+- `name`
+- `parent_id`
+  - use `""` to make the category a root category
+- `sort_children`
+  - full ordered list of all child ids
+
+Rules:
+
+- `parent_id` and `sort_children` cannot be used in the same request
+- sorting root categories uses the special `/root` endpoint
+- sorting subcategories requires a full child order, not a partial reorder
+
+### Delete category
+
+- `DELETE /categories/file/:category_id`
+- `DELETE /categories/product/:category_id`
+
+Rules:
+
+- deleting a category deletes its entire subtree
+- if you need to preserve children, move them first
+- if the category or any descendant is used as an E-Catalog root category, the scrape says deletion returns `409 Conflict`
+
+### Search categories
+
+- `POST /categories/file/search`
+- `POST /categories/product/search`
+
+Searchable fields shown in the scrape:
+
+- `id`
+- `name`
+- `path`
+- `parents_ids`
+- `n_children`
+- `order`
+
+Restrictions shown in the scrape:
+
+- requested attributes must be explicitly listed, except `id`
+- sorting by a non-returned attribute is allowed
+- invalid field/operator/value combinations return `422`
+- `pagination.page_size` max is `100`
+
+## Products v1
+
+### Product model
+
+The scrape documents a product as:
+
+- system fields:
+  - `sku`
+  - `label`
+  - `gtin`
+  - `id`
+  - `created`
+  - `modified`
+  - `num_variations`
+  - `status`
+  - `assets`
+  - `categories`
+  - `thumbnail`
+  - `attributes`
+  - `product_family_id`
+- custom attributes:
+  - short text
+  - paragraph
+  - rich text
+  - integer
+  - decimal
+  - dropdown
+  - multiselect
+  - URL
+  - media
+  - media gallery
+  - boolean
+  - date
+
+### Linked field structures
+
+#### Asset-like structure
+
+Used for:
+
+- `assets`
+- `thumbnail`
+- media attributes
+- media gallery items
+
+Fields shown:
+
+- `id`
+- `filename`
+- `file_size`
+- `thumbnail` or `thumb`
+- `url`
+
+#### Category structure
+
+Fields shown:
+
+- `id`
+- `name`
+- `path`
+
+### `POST /products`
+
+Minimal requirement:
+
+```json
+{
+  "sku": "unique-sku"
+}
+```
+
+Notes:
+
+- unknown and readonly fields are ignored
+- this endpoint does not create new assets or categories
+- existing assets and categories can be linked at creation time
+- success returns `201 Created`
+
+### `GET /products/:product_id`
+
+Notes:
+
+- optional query parameter: `all_attributes=true|false`
+- default is `false`
+- when `true`, empty defined attributes are returned as `null`
+
+### `PATCH /products/:product_id`
+
+- partial update
+- unspecified fields are left unchanged
+- examples show patching both system fields and `attributes`
+
+### `DELETE /products/:product_id`
+
+Rules:
+
+- deleting a parent product deletes its linked variants
+- unlink variants first if you need to preserve them
+
+### `POST /products/:product_id/family`
+
+Body:
+
+```json
+{
+  "product_family_id": "<product_family_id or empty string>"
+}
+```
+
+Notes:
+
+- setting `""` unassigns the family
+- changing family may cause data loss
+- family cannot be assigned to variant products
+- changing a parent's family also affects its variants
+
+### `POST /products/search`
+
+Important rules from the scrape:
+
+- up to `50` requested attributes/properties, plus `id` and `sku`
+- user attributes must be requested as `attributes.<label>`
+- relationship response columns must be requested as `relationships.<label>`
+- requested fields must exist or the API returns `422`
+- invalid field/operator/value combinations return `422`
+- if more than `10000` products match and `pagination.order` is set, the API returns `428`
+- `page_size` max is `100`
+- only one relationship can be selected in filters
+
+### Relationship filters in product search
+
+The scrape documents a separate `relationship_filters` array for product search.
+
+Structure:
+
+```json
+{
+  "relationship_id": "rel_id",
+  "operator": "exists",
+  "product_ids": [
+    {
+      "id": "product_id",
+      "qty_operator": "gt",
+      "value": [2]
+    }
+  ]
+}
+```
+
+Supported `operator` on relationship filter objects:
+
+- `exists`
+- `!exists`
+
+Supported `qty_operator` values shown:
+
+- `exists`
+- `eq`
+- `in`
+- `gt`
+- `gte`
+- `lt`
+- `lte`
+- `bte`
+- `last_days`
+
+### Linked assets v1
+
+#### `GET /products/:product_id/assets`
+
+- returns linked assets
+
+#### `GET /products/:product_id/assets/:asset_id`
+
+- returns one linked asset
+
+#### `POST /products/:product_id/assets`
+
+Links an existing asset to:
+
+- `thumbnail`
+- a single media attribute
+- a media gallery attribute
+
+Body:
+
+```json
+{
+  "id": "asset_id",
+  "attribute_label": "thumbnail"
+}
+```
+
+Rules:
+
+- the asset must already exist
+- the attribute must already exist
+- thumbnail and single-media linking replace the existing asset
+- media-gallery linking appends
+- max `300` linked assets per product
+
+#### `DELETE /products/:product_id/assets/:asset_id`
+
+- unlinks the asset from the product
+- does not delete the asset from the account
+
+### Linked categories v1
+
+#### `GET /products/:product_id/categories`
+
+- lists linked categories
+
+#### `GET /products/:product_id/categories/:category_id`
+
+- returns one linked category
+
+#### `POST /products/:product_id/categories`
+
+Body:
+
+```json
+{
+  "id": "category_id"
+}
+```
+
+#### `DELETE /products/:product_id/categories/:category_id`
+
+- unlinks the category from the product
+
+## Variants v1
+
+The scrape distinguishes:
+
+- `PARENT`
+- `VARIANT`
+- `SINGLE`
+
+Notes:
+
+- variants are added through product families
+- parent-level attributes can be inherited
+- linking/unlinking variants may cause data loss
+
+### `POST /products/:product_id/variant/:variant_id`
+
+- links an existing single product as a variant of another product
+- both products must belong to the same family or both be unassigned
+
+### `DELETE /products/:parent_product_id/variant/:variant_id`
+
+- detaches a variant and turns it back into a single product
+
+### `POST /products/:parent_product_id/variants`
+
+Body shape:
+
+```json
+{
+  "variant": {
+    "sku": "new-variant-sku",
+    "label": "optional label",
+    "attributes": {
+      "some_attribute_label": "value"
+    }
+  }
+}
+```
+
+Notes:
+
+- `variant.sku` is required
+- if you set a parent-level attribute on creation, it becomes overwritten on the variant
+
+### `POST /products/:parent_product_id/variants/resync`
+
+Body:
+
+```json
+{
+  "attribute_labels": ["attr_1", "attr_2"],
+  "variant_ids": ["variant_id_1", "variant_id_2"]
+}
+```
+
+- resets listed parent-level attributes on listed variants back to the parent value
+
+## Product relationship operations v1
+
+These endpoints manage products related through an existing relationship definition.
+
+### `POST /products/:product_id/relationships/:relationship_id`
+
+Body:
+
+```json
+{
+  "product_relationships": [
+    {
+      "product_id": "related_product_id",
+      "quantity": 1
+    }
+  ]
+}
+```
+
+Behavior documented in the scrape:
+
+- existing entries are updated
+- missing entries are inserted
+- returns `201` when changes are made
+- may return `200` when nothing changes
+
+### `POST /products/:product_id/relationships/:relationship_id/unlink`
+
+Body:
+
+```json
+{
+  "product_relationships": [
+    {
+      "product_id": "related_product_id"
+    }
+  ]
+}
+```
+
+Notes:
+
+- detailed section documents `/unlink`
+- earlier summary table and some examples are inconsistent
+- success is documented as `204 No Content`
+
+### `PATCH /products/:product_id/relationships/:relationship_id/product/:related_product_id`
+
+Body:
+
+```json
+{
+  "quantity": 10
+}
+```
+
+- updates quantity for a specific related product
+
+## Products v2 beta
+
+The v2 beta keeps the same broad product domain, but the main shape changes are important:
+
+- create and patch return ids and audit metadata, not the full hydrated product
+- `GET /products/:id` returns linked media/categories as ids, not expanded objects
+- search responses do not expand category/media structures
+- relationship mutation endpoints are more forgiving and silently ignore bad ids
+
+### v2 product fields shown in the scrape
+
+- `id`
+- `created`
+- `modified`
+- `created_user_audit`
+- `modified_user_audit`
+- `account_id`
+- `sku`
+- `label`
+- `status`
+- `attributes`
+- `assets` or `asset_ids`-style content represented as ids
+- `categories` or `category_ids`-style content represented as ids
+- `thumbnail` as asset ids
+- `relationships`
+- `product_family_id`
+- `overwritten_attributes`
+- `product_type`
+- `product_level`
+- `num_variations`
+- `static_list_ids`
+- `mark_as_deleted`
+
+The prose in the scrape says `asset_ids` and `category_ids`, while the example payload uses `assets` and `categories` arrays containing ids. Treat both as the v2 "ids only, not expanded objects" concept.
+
+### `POST /products`
+
+- creates a product
+- success returns only product id and audit metadata
+
+### `GET /products/:product_id`
+
+- returns product data
+- linked assets, categories, thumbnail, media, and media galleries are represented as ids
+- to expand categories or assets, use the dedicated nested endpoints
+
+### `PATCH /products/:product_id`
+
+- partial update
+- success returns id plus audit metadata
+
+### `DELETE /products/:product_id`
+
+- deletes the product
+- as in v1, deleting a parent also deletes its variants unless unlinked first
+
+### `POST /products/:product_id/family`
+
+- same semantics as v1
+- response is smaller: id + timestamps + audit metadata
+
+### `POST /products/search`
+
+Same major request rules as v1 product search, plus one key response difference:
+
+- requested media/category fields are not expanded into full structures in v2 search responses
+
+## Linked assets v2 beta
+
+### `GET /products/:product_id/assets`
+
+- lists expanded linked assets for the product
+
+### `POST /products/:product_id/assets`
+
+- same asset-linking semantics as v1
+- request body still uses:
+
+```json
+{
+  "id": "asset_id",
+  "attribute_label": "thumbnail"
+}
+```
+
+### `DELETE /products/:product_id/assets/:asset_id`
+
+- unlinks asset from product
+
+## Linked categories v2 beta
+
+### `GET /products/:product_id/categories`
+
+- lists expanded linked categories for the product
+
+### `POST /products/:product_id/categories`
+
+- links a category by id
+
+### `DELETE /products/:product_id/categories/:category_id`
+
+- unlinks category from product
+
+## Variants v2 beta
+
+The v2 beta variant model adds the notion of `SUB-VARIANT` in the prose, although the example responses still mainly show parent/single/variant flows.
+
+### `POST /products/:product_id/variant/:variant_id`
+
+- links an existing product as a variant
+- prose says success is `204 No Content`
+- example shows an empty JSON body; treat this as an empty-success mutation
+
+### `DELETE /products/:parent_product_id/variant/:variant_id`
+
+- unlinks a variant from its parent
+- empty-success response
+
+### `POST /products/:parent_product_id/variants`
+
+Body:
+
+```json
+{
+  "sku": "new-variant-sku",
+  "label": "optional label",
+  "attributes": {
+    "some_attribute_label": "value"
+  }
+}
+```
+
+Notes:
+
+- unlike v1, the request body is the variant object itself, not nested under `variant`
+- success returns the new product id and audit metadata
+
+### `POST /products/:parent_product_id/variants/resync`
+
+- same request shape and semantics as v1
+
+## Product relationship operations v2 beta
+
+### `POST /products/:product_id/relationships/:relationship_id`
+
+- request shape is still:
+
+```json
+{
+  "product_relationships": [
+    {
+      "product_id": "related_product_id",
+      "quantity": 1
+    }
+  ]
+}
+```
+
+- documented behavior:
+  - nonexistent products are silently ignored
+  - already-added products are silently ignored
+  - no validation-style error is returned for those cases
+  - success returns `200 OK`
+
+### `DELETE /products/:product_id/relationships/:relationship_id`
+
+Body:
+
+```json
+{
+  "product_relationships": [
+    "related_product_id_1",
+    "related_product_id_2"
+  ]
+}
+```
+
+- ids not linked to the relationship are silently ignored
+- success is `204 No Content`
+
+### `PATCH /products/:product_id/relationships/:relationship_id`
+
+Body:
+
+```json
+{
+  "product_relationships": [
+    {
+      "product_id": "related_product_id",
+      "quantity": 9
+    }
+  ]
+}
+```
+
+- nonexistent or unlinked products are silently ignored
+- success is `200 OK`
+
+## Product attributes v1
+
+### Attribute types in the scrape
+
+| Type class | PIM name | Notes |
+| --- | --- | --- |
+| `TextAttribute` | Short Text | short text |
+| `MultilineAttribute` | Paragraph | plain multiline text |
+| `HtmlAttribute` | Rich Text | HTML content |
+| `IntAttribute` | Integer Number | integers |
+| `DecimalAttribute` | Decimal Number | decimal numbers |
+| `DropdownAttribute` | Dropdown | single select |
+| `MultiSelectAttribute` | MultiSelect | multi select |
+| `DateAttribute` | Date | ISO-style date values |
+| `UrlAttribute` | Url | links |
+| `BooleanAttribute` | Boolean | true/false |
+| `MediaAttribute` | Media | single linked asset |
+| `MediaGalleryAttribute` | MediaGallery | multiple linked assets |
+| `CompletenessAttribute` | Completeness | completeness scoring |
+
+### `GET /attributes/product/:product_attribute_id`
+
+- returns one product attribute
+- fields shown:
+  - `id`
+  - `label`
+  - `name`
+  - `type_class`
+  - `groups`
+
+### `PATCH /attributes/product/:product_attribute_id`
+
+Patchable fields documented in the scrape:
+
+- all attributes:
+  - `name`
+  - `description`
+- dropdown and multiselect:
+  - `options`
+    - replacing options replaces the full existing option set
+- completeness attributes:
+  - `attributes`
+
+## Known scrape artifacts and contradictions
+
+These were normalized in this cleaned version instead of copied verbatim.
+
+- The raw scrape contains many repeated `Body` / `Headers (N)` UI fragments.
+- Many JSON examples contain escaped backslashes from the scraper.
+- The initial resource summary lists `GET /filters/products`; the detailed section uses `GET /filters/product`. This document uses `filters/product`.
+- Product relationship unlinking in v1 is inconsistent:
+  - summary table shows `/products/:id/relationships/:id/unlink`
+  - detailed heading shows `POST .../unlink`
+  - one example omits `/unlink`
+- The v1 `GET /products/:product_id/variants` section includes a malformed example curl using `POST`.
+- Several example headings show `200 OK` while the prose and empty-body behavior imply `204 No Content`.
+- v2 prose describes ids-only fields with names like `asset_ids` and `category_ids`, while examples often use `assets` and `categories` arrays that contain ids. The meaningful difference is that v2 core product responses do not expand linked entities.
+
+## Practical takeaways
+
+- Use auth token flow first; tokens are short-lived.
+- Use `GET /api/v1/filters/product` to discover valid product attribute labels and filter operators.
+- Use product search with explicit `attributes`.
+- Use v2 product endpoints if you want the newer lightweight product payloads.
+- Use nested assets/categories endpoints when you need expanded linked objects in v2.
+- Expect search hard limits around:
+  - `page_size <= 100`
+  - `428` when ordering very large result sets
+  - product search attribute limit of `50`
+

--- a/docs/superpowers/plans/2026-03-11-mcp-scope-revision.md
+++ b/docs/superpowers/plans/2026-03-11-mcp-scope-revision.md
@@ -1,0 +1,1397 @@
+# Plytix MCP Scope Revision — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 17 new operational tools to the Plytix MCP (variants lifecycle, asset ops, category search, relationship discovery, family ops, filter discovery split) while maintaining dual-runtime parity (stdio + worker).
+
+**Architecture:** Each new tool follows the established pattern: (1) add client method to `client.ts` + `worker-client.ts`, (2) register tool in `src/tools/*.ts`, (3) add worker handler to `src/worker.ts`. All new tools use the existing `registerTool()` wrapper and match the JSON response shape convention (`{ success, action, ...ids }` for writes, raw data for reads).
+
+**Tech Stack:** TypeScript, Zod, MCP SDK, Vitest, Cloudflare Workers
+
+**Dual-runtime note:** Every client method added to `client.ts` MUST also be added to `worker-client.ts`. Every tool registered in `src/tools/*.ts` MUST also get a handler in `src/worker.ts`. The worker uses inline JSON Schema (not Zod) for tool definitions.
+
+**API endpoint verification:** Some endpoints in this plan come from the spec and have not been verified against the live Plytix API. Endpoints marked with ⚠️ should be tested manually before implementation. If an endpoint returns 404, check Plytix API docs for the correct path.
+
+---
+
+## File Structure
+
+**Files to modify:**
+
+| File | Changes |
+|------|---------|
+| `src/types.ts` | Add `PlytixRelationshipDefinition` type |
+| `src/client.ts` | Add ~15 new client methods |
+| `src/worker-client.ts` | Mirror all new client methods |
+| `src/tools/variants.ts` | Add `variants_create`, `variants_link`, `variants_unlink` |
+| `src/tools/assets.ts` | Add `assets_get`, `assets_search`, `assets_update` |
+| `src/tools/categories.ts` | Add `categories_search` |
+| `src/tools/relationships.ts` | Add `relationships_get`, `relationships_search` |
+| `src/tools/families.ts` | Add `families_create`, `families_link_attribute`, `families_unlink_attribute`, `families_list_attributes`, `families_list_all_attributes` |
+| `src/tools/attributes.ts` | Deprecate `attributes_filters`, add `products_filters`, `assets_filters`, `relationships_filters` |
+| `src/worker.ts` | Add all 17 new tool definitions + handlers, deprecate old filter tool |
+| `CLAUDE.md` | Update tool tables |
+
+---
+
+## Phase 1: Types + Client Methods (all plumbing, no tools yet)
+
+### Task 1: Add PlytixRelationshipDefinition type
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Add type after `PlytixRelationship` interface (~line 117)**
+
+```typescript
+export interface PlytixRelationshipDefinition {
+  id: string;
+  label: string;
+  name?: string;
+  created?: string;
+  modified?: string;
+  [key: string]: unknown;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat: add PlytixRelationshipDefinition type"
+```
+
+### Task 2: Add variant lifecycle client methods
+
+**Files:**
+- Modify: `src/client.ts` (after `resyncVariants`, ~line 602)
+- Modify: `src/worker-client.ts` (after `resyncVariants`, ~line 584)
+
+⚠️ **Endpoint note:** Variant link/unlink use singular `/variant/{id}` — verify against Plytix API. If Plytix uses plural `/variants/{id}`, update the path.
+
+- [ ] **Step 1: Add to client.ts**
+
+```typescript
+async createVariant(
+  parentProductId: string,
+  data: { sku: string; label?: string; attributes?: Record<string, unknown> }
+): Promise<PlytixResult<PlytixProduct>> {
+  return this.request<PlytixProduct>(
+    `/api/v1/products/${encodeURIComponent(parentProductId)}/variants`,
+    { method: 'POST', body: JSON.stringify(data) }
+  );
+}
+
+async linkVariant(
+  parentProductId: string,
+  variantProductId: string
+): Promise<PlytixResult<PlytixProduct>> {
+  return this.request<PlytixProduct>(
+    `/api/v1/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+    { method: 'POST' }
+  );
+}
+
+async unlinkVariant(
+  parentProductId: string,
+  variantProductId: string
+): Promise<PlytixResult<void>> {
+  return this.request<void>(
+    `/api/v1/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+    { method: 'DELETE' }
+  );
+}
+```
+
+- [ ] **Step 2: Mirror identical methods in worker-client.ts**
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add variant create/link/unlink client methods"
+```
+
+### Task 3: Add asset operation client methods
+
+**Files:**
+- Modify: `src/client.ts` (after `searchAssets`, ~line 396)
+- Modify: `src/worker-client.ts` (after `searchAssets`, ~line 563)
+
+- [ ] **Step 1: Add to client.ts**
+
+```typescript
+async getAsset(assetId: string): Promise<PlytixResult<PlytixAsset>> {
+  return this.request<PlytixAsset>(`/api/v2/assets/${encodeURIComponent(assetId)}`);
+}
+
+async updateAsset(
+  assetId: string,
+  data: { filename?: string; categories?: string[] }
+): Promise<PlytixResult<PlytixAsset>> {
+  return this.request<PlytixAsset>(`/api/v2/assets/${encodeURIComponent(assetId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+```
+
+- [ ] **Step 2: Mirror in worker-client.ts**
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add asset get/update client methods"
+```
+
+### Task 4: Add category search client method
+
+**Files:**
+- Modify: `src/client.ts` (after `unlinkProductCategory`)
+- Modify: `src/worker-client.ts`
+
+⚠️ **Endpoint note:** `POST /api/v1/categories/product/search` — verify this path exists in Plytix API. May be `/api/v2/categories/search` instead.
+
+- [ ] **Step 1: Add to client.ts**
+
+```typescript
+async searchCategories(body?: PlytixSearchBody): Promise<PlytixResult<PlytixCategory>> {
+  return this.request<PlytixCategory>('/api/v1/categories/product/search', {
+    method: 'POST',
+    body: JSON.stringify(body ?? {}),
+  });
+}
+```
+
+- [ ] **Step 2: Mirror in worker-client.ts**
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add category search client method"
+```
+
+### Task 5: Add relationship discovery client methods
+
+**Files:**
+- Modify: `src/client.ts` (before `linkProductRelationship`)
+- Modify: `src/worker-client.ts`
+
+⚠️ **Endpoint note:** `GET /api/v1/relationships/{id}` and `POST /api/v1/relationships/search` — these are for relationship *definitions*, not product-relationship instances. Verify these standalone endpoints exist.
+
+- [ ] **Step 1: Add to client.ts** (update import to include `PlytixRelationshipDefinition`)
+
+```typescript
+async getRelationship(relationshipId: string): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+  return this.request<PlytixRelationshipDefinition>(
+    `/api/v1/relationships/${encodeURIComponent(relationshipId)}`
+  );
+}
+
+async searchRelationships(body?: PlytixSearchBody): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+  return this.request<PlytixRelationshipDefinition>('/api/v1/relationships/search', {
+    method: 'POST',
+    body: JSON.stringify(body ?? {}),
+  });
+}
+```
+
+- [ ] **Step 2: Mirror in worker-client.ts** (update import too)
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add relationship get/search client methods"
+```
+
+### Task 6: Add family operation client methods
+
+**Files:**
+- Modify: `src/client.ts` (after `getFamily`)
+- Modify: `src/worker-client.ts`
+
+- [ ] **Step 1: Add to client.ts** (update import to include `PlytixFamilyAttribute`)
+
+```typescript
+async createFamily(data: { name: string; parent_id?: string }): Promise<PlytixResult<PlytixFamily>> {
+  return this.request<PlytixFamily>('/api/v1/product_families', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+async linkFamilyAttributes(
+  familyId: string,
+  attributeLabels: string[]
+): Promise<PlytixResult<void>> {
+  return this.request<void>(
+    `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/link`,
+    { method: 'POST', body: JSON.stringify({ attributes: attributeLabels }) }
+  );
+}
+
+async unlinkFamilyAttributes(
+  familyId: string,
+  attributeLabels: string[]
+): Promise<PlytixResult<void>> {
+  return this.request<void>(
+    `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/unlink`,
+    { method: 'POST', body: JSON.stringify({ attributes: attributeLabels }) }
+  );
+}
+
+async getFamilyAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+  return this.request<PlytixFamilyAttribute>(
+    `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes`
+  );
+}
+
+async getFamilyAllAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+  return this.request<PlytixFamilyAttribute>(
+    `/api/v1/product_families/${encodeURIComponent(familyId)}/all_attributes`
+  );
+}
+```
+
+- [ ] **Step 2: Mirror in worker-client.ts** (update import too)
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add family create/link-attr/unlink-attr/list-attrs client methods"
+```
+
+### Task 7: Add filter discovery client methods
+
+**Files:**
+- Modify: `src/client.ts` (after `getAvailableFilters`)
+- Modify: `src/worker-client.ts`
+
+⚠️ **Endpoint note:** `GET /api/v1/assets/search/filters` and `GET /api/v1/relationships/search/filters` — parallel pattern to existing product filters endpoint. Verify these exist.
+
+- [ ] **Step 1: Add to client.ts**
+
+```typescript
+async getAssetFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+  return this.request<PlytixFilterDefinition>('/api/v1/assets/search/filters');
+}
+
+async getRelationshipFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+  return this.request<PlytixFilterDefinition>('/api/v1/relationships/search/filters');
+}
+```
+
+- [ ] **Step 2: Mirror in worker-client.ts**
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/client.ts src/worker-client.ts
+git commit -m "feat: add asset and relationship filter discovery client methods"
+```
+
+---
+
+## Phase 2: Variant Lifecycle Tools (stdio)
+
+### Task 8: Add variants_create tool
+
+**Files:**
+- Modify: `src/tools/variants.ts`
+
+- [ ] **Step 1: Add tool after `variants_resync`**
+
+```typescript
+// CREATE variant under parent
+registerTool<{ parent_product_id: string; sku: string; label?: string; attributes?: Record<string, unknown> }>(
+  server,
+  'variants_create',
+  {
+    title: 'Create Variant',
+    description: 'Create a new variant beneath a parent product. Inherits family and attributes from parent.',
+    inputSchema: {
+      parent_product_id: z.string().min(1).describe('The parent product ID'),
+      sku: z.string().min(1).describe('SKU for the new variant'),
+      label: z.string().optional().describe('Optional label for the variant'),
+      attributes: z.record(z.unknown()).optional().describe('Optional attributes to override on the variant'),
+    },
+  },
+  async ({ parent_product_id, sku, label, attributes }) => {
+    try {
+      const data: { sku: string; label?: string; attributes?: Record<string, unknown> } = { sku };
+      if (label !== undefined) data.label = label;
+      if (attributes !== undefined) data.attributes = attributes;
+
+      const result = await client.createVariant(parent_product_id, data);
+      const variant = result.data?.[0];
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true, action: 'created', parent_product_id,
+            variant: variant ? { id: variant.id, sku: variant.sku, label: variant.label } : undefined,
+          }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error creating variant: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tools/variants.ts
+git commit -m "feat: add variants_create tool"
+```
+
+### Task 9: Add variants_link tool
+
+**Files:**
+- Modify: `src/tools/variants.ts`
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// LINK existing product as variant
+registerTool<{ parent_product_id: string; variant_product_id: string }>(
+  server,
+  'variants_link',
+  {
+    title: 'Link Variant',
+    description: 'Convert an existing standalone product into a variant of a parent product.',
+    inputSchema: {
+      parent_product_id: z.string().min(1).describe('The parent product ID'),
+      variant_product_id: z.string().min(1).describe('The existing product ID to link as a variant'),
+    },
+  },
+  async ({ parent_product_id, variant_product_id }) => {
+    try {
+      await client.linkVariant(parent_product_id, variant_product_id);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ success: true, action: 'linked', parent_product_id, variant_product_id }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error linking variant: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/variants.ts
+git commit -m "feat: add variants_link tool"
+```
+
+### Task 10: Add variants_unlink tool
+
+**Files:**
+- Modify: `src/tools/variants.ts`
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// UNLINK variant from parent (product not deleted)
+registerTool<{ parent_product_id: string; variant_product_id: string }>(
+  server,
+  'variants_unlink',
+  {
+    title: 'Unlink Variant',
+    description: 'Unlink a variant from its parent product. The underlying product is not deleted.',
+    inputSchema: {
+      parent_product_id: z.string().min(1).describe('The parent product ID'),
+      variant_product_id: z.string().min(1).describe('The variant product ID to unlink'),
+    },
+  },
+  async ({ parent_product_id, variant_product_id }) => {
+    try {
+      await client.unlinkVariant(parent_product_id, variant_product_id);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ success: true, action: 'unlinked', parent_product_id, variant_product_id }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error unlinking variant: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/variants.ts
+git commit -m "feat: add variants_unlink tool"
+```
+
+---
+
+## Phase 3: Asset Operation Tools (stdio)
+
+### Task 11: Add assets_get tool
+
+**Files:**
+- Modify: `src/tools/assets.ts` (before `assets_link`)
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// GET single asset by ID
+registerTool<{ asset_id: string }>(
+  server,
+  'assets_get',
+  {
+    title: 'Get Asset',
+    description: 'Get a single asset by ID with full metadata.',
+    inputSchema: {
+      asset_id: z.string().min(1).describe('The asset ID'),
+    },
+  },
+  async ({ asset_id }) => {
+    try {
+      const result = await client.getAsset(asset_id);
+      const asset = result.data?.[0];
+      if (!asset) {
+        return { content: [{ type: 'text', text: `Asset not found: ${asset_id}` }], isError: true };
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(asset, null, 2) }] };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching asset: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/assets.ts
+git commit -m "feat: add assets_get tool"
+```
+
+### Task 12: Add assets_search tool
+
+**Files:**
+- Modify: `src/tools/assets.ts`
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// SEARCH assets
+registerTool<{
+  filters?: Array<Array<{ field: string; operator: string; value?: unknown }>>;
+  pagination?: { page?: number; page_size?: number };
+  sort?: unknown;
+}>(
+  server,
+  'assets_search',
+  {
+    title: 'Search Assets',
+    description: 'Search assets with filters, pagination, and sorting.',
+    inputSchema: {
+      filters: z.array(z.array(z.object({
+        field: z.string(), operator: z.string(), value: z.unknown().optional(),
+      }))).optional().describe('Search filters (AND groups of OR conditions)'),
+      pagination: z.object({
+        page: z.number().int().positive().optional(),
+        page_size: z.number().int().positive().max(100).optional(),
+      }).optional().describe('Pagination options'),
+      sort: z.unknown().optional().describe('Sort options'),
+    },
+  },
+  async ({ filters, pagination, sort }) => {
+    try {
+      const body: Record<string, unknown> = {};
+      if (filters) body.filters = filters;
+      if (pagination) body.pagination = pagination;
+      if (sort) body.sort = sort;
+
+      const result = await client.searchAssets(body);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ assets: result.data, pagination: result.pagination }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error searching assets: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/assets.ts
+git commit -m "feat: add assets_search tool"
+```
+
+### Task 13: Add assets_update tool
+
+**Files:**
+- Modify: `src/tools/assets.ts`
+
+**Guardrail:** Only `filename` and `categories` are patchable — enforced at type level, schema level, and handler validation.
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// UPDATE asset metadata (filename and categories only)
+registerTool<{ asset_id: string; filename?: string; categories?: string[] }>(
+  server,
+  'assets_update',
+  {
+    title: 'Update Asset',
+    description: 'Update asset metadata. Only filename and categories can be changed. No binary replacement.',
+    inputSchema: {
+      asset_id: z.string().min(1).describe('The asset ID'),
+      filename: z.string().optional().describe('New filename for the asset'),
+      categories: z.array(z.string()).optional().describe('Asset categories to set'),
+    },
+  },
+  async ({ asset_id, filename, categories }) => {
+    try {
+      if (filename === undefined && categories === undefined) {
+        return {
+          content: [{ type: 'text', text: 'Error: At least one of filename or categories must be provided' }],
+          isError: true,
+        };
+      }
+
+      const data: { filename?: string; categories?: string[] } = {};
+      if (filename !== undefined) data.filename = filename;
+      if (categories !== undefined) data.categories = categories;
+
+      await client.updateAsset(asset_id, data);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true, action: 'updated', asset_id,
+            ...(filename !== undefined ? { filename } : {}),
+            ...(categories !== undefined ? { categories } : {}),
+          }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error updating asset: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/assets.ts
+git commit -m "feat: add assets_update tool"
+```
+
+---
+
+## Phase 4: Category Search + Relationship Discovery Tools (stdio)
+
+### Task 14: Add categories_search tool
+
+**Files:**
+- Modify: `src/tools/categories.ts` (before `categories_link`)
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// SEARCH categories
+registerTool<{ query?: string; pagination?: { page?: number; page_size?: number } }>(
+  server,
+  'categories_search',
+  {
+    title: 'Search Categories',
+    description: 'Search existing product categories by name.',
+    inputSchema: {
+      query: z.string().optional().describe('Search query to filter categories by name'),
+      pagination: z.object({
+        page: z.number().int().positive().optional(),
+        page_size: z.number().int().positive().max(100).optional(),
+      }).optional().describe('Pagination options'),
+    },
+  },
+  async ({ query, pagination }) => {
+    try {
+      const body: Record<string, unknown> = {};
+      if (pagination) body.pagination = pagination;
+      if (query) body.filters = [[{ field: 'name', operator: 'like', value: query }]];
+
+      const result = await client.searchCategories(body);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ categories: result.data, pagination: result.pagination }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error searching categories: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/categories.ts
+git commit -m "feat: add categories_search tool"
+```
+
+### Task 15: Add relationships_get tool
+
+**Files:**
+- Modify: `src/tools/relationships.ts` (at top of function, before existing tools)
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// GET relationship definition by ID
+registerTool<{ relationship_id: string }>(
+  server,
+  'relationships_get',
+  {
+    title: 'Get Relationship',
+    description: 'Get a relationship definition by ID.',
+    inputSchema: {
+      relationship_id: z.string().min(1).describe('The relationship definition ID'),
+    },
+  },
+  async ({ relationship_id }) => {
+    try {
+      const result = await client.getRelationship(relationship_id);
+      const rel = result.data?.[0];
+      if (!rel) {
+        return { content: [{ type: 'text', text: `Relationship not found: ${relationship_id}` }], isError: true };
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(rel, null, 2) }] };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching relationship: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/relationships.ts
+git commit -m "feat: add relationships_get tool"
+```
+
+### Task 16: Add relationships_search tool
+
+**Files:**
+- Modify: `src/tools/relationships.ts`
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// SEARCH relationship definitions
+registerTool<{ query?: string; pagination?: { page?: number; page_size?: number } }>(
+  server,
+  'relationships_search',
+  {
+    title: 'Search Relationships',
+    description: 'Search or list available relationship definitions.',
+    inputSchema: {
+      query: z.string().optional().describe('Search query to filter relationships by name'),
+      pagination: z.object({
+        page: z.number().int().positive().optional(),
+        page_size: z.number().int().positive().max(100).optional(),
+      }).optional().describe('Pagination options'),
+    },
+  },
+  async ({ query, pagination }) => {
+    try {
+      const body: Record<string, unknown> = {};
+      if (pagination) body.pagination = pagination;
+      if (query) body.filters = [[{ field: 'label', operator: 'like', value: query }]];
+
+      const result = await client.searchRelationships(body);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ relationships: result.data, pagination: result.pagination }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error searching relationships: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/relationships.ts
+git commit -m "feat: add relationships_search tool"
+```
+
+---
+
+## Phase 5: Family Operation Tools (stdio)
+
+### Task 17: Add families_create tool
+
+**Files:**
+- Modify: `src/tools/families.ts`
+
+- [ ] **Step 1: Add tool**
+
+```typescript
+// CREATE family
+registerTool<{ name: string; parent_id?: string }>(
+  server,
+  'families_create',
+  {
+    title: 'Create Product Family',
+    description: 'Create a new product family. Optionally specify a parent family for inheritance.',
+    inputSchema: {
+      name: z.string().min(1).describe('Name for the new family'),
+      parent_id: z.string().optional().describe('Optional parent family ID for inheritance'),
+    },
+  },
+  async ({ name, parent_id }) => {
+    try {
+      const data: { name: string; parent_id?: string } = { name };
+      if (parent_id !== undefined) data.parent_id = parent_id;
+
+      const result = await client.createFamily(data);
+      const family = result.data?.[0];
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true, action: 'created',
+            family: family ? { id: family.id, name: family.name } : undefined,
+          }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error creating family: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/families.ts
+git commit -m "feat: add families_create tool"
+```
+
+### Task 18: Add families_link_attribute + families_unlink_attribute tools
+
+**Files:**
+- Modify: `src/tools/families.ts`
+
+- [ ] **Step 1: Add both tools**
+
+```typescript
+// LINK attributes to family
+registerTool<{ family_id: string; attribute_labels: string[] }>(
+  server,
+  'families_link_attribute',
+  {
+    title: 'Link Attribute to Family',
+    description: 'Link one or more attributes to a product family.',
+    inputSchema: {
+      family_id: z.string().min(1).describe('The product family ID'),
+      attribute_labels: z.array(z.string()).min(1).describe('Attribute labels to link (snake_case identifiers)'),
+    },
+  },
+  async ({ family_id, attribute_labels }) => {
+    try {
+      await client.linkFamilyAttributes(family_id, attribute_labels);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ success: true, action: 'linked', family_id, attribute_labels, count: attribute_labels.length }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error linking attributes: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// UNLINK attributes from family
+registerTool<{ family_id: string; attribute_labels: string[] }>(
+  server,
+  'families_unlink_attribute',
+  {
+    title: 'Unlink Attribute from Family',
+    description: 'Remove one or more attributes from a product family.',
+    inputSchema: {
+      family_id: z.string().min(1).describe('The product family ID'),
+      attribute_labels: z.array(z.string()).min(1).describe('Attribute labels to unlink (snake_case identifiers)'),
+    },
+  },
+  async ({ family_id, attribute_labels }) => {
+    try {
+      await client.unlinkFamilyAttributes(family_id, attribute_labels);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ success: true, action: 'unlinked', family_id, attribute_labels, count: attribute_labels.length }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error unlinking attributes: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/families.ts
+git commit -m "feat: add families_link_attribute and families_unlink_attribute tools"
+```
+
+### Task 19: Add families_list_attributes + families_list_all_attributes tools
+
+**Files:**
+- Modify: `src/tools/families.ts`
+
+- [ ] **Step 1: Add both tools**
+
+```typescript
+// LIST family attributes (directly linked only)
+registerTool<{ family_id: string }>(
+  server,
+  'families_list_attributes',
+  {
+    title: 'List Family Attributes',
+    description: 'List attributes directly linked to a family (not inherited from parent).',
+    inputSchema: {
+      family_id: z.string().min(1).describe('The product family ID'),
+    },
+  },
+  async ({ family_id }) => {
+    try {
+      const result = await client.getFamilyAttributes(family_id);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ family_id, attributes: result.data, count: result.data?.length ?? 0 }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error listing family attributes: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// LIST all family attributes (including inherited)
+registerTool<{ family_id: string }>(
+  server,
+  'families_list_all_attributes',
+  {
+    title: 'List All Family Attributes',
+    description: 'List all attributes for a family, including those inherited from parent families.',
+    inputSchema: {
+      family_id: z.string().min(1).describe('The product family ID'),
+    },
+  },
+  async ({ family_id }) => {
+    try {
+      const result = await client.getFamilyAllAttributes(family_id);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ family_id, attributes: result.data, count: result.data?.length ?? 0 }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error listing all family attributes: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/families.ts
+git commit -m "feat: add families_list_attributes and families_list_all_attributes tools"
+```
+
+---
+
+## Phase 6: Filter Discovery Split (stdio)
+
+### Task 20: Deprecate attributes_filters, add products_filters + assets_filters + relationships_filters
+
+**Files:**
+- Modify: `src/tools/attributes.ts`
+
+**Strategy:** Keep `attributes_filters` as a deprecated alias (returns product filters with a deprecation notice). Add three new explicit filter tools.
+
+- [ ] **Step 1: Replace the `attributes_filters` registration (~line 193-233) with four tools**
+
+```typescript
+// ─────────────────────────────────────────────────────────────
+// attributes_filters (DEPRECATED - use products_filters instead)
+// ─────────────────────────────────────────────────────────────
+
+registerTool<Record<string, never>>(
+  server,
+  'attributes_filters',
+  {
+    title: 'Get Search Filters (Deprecated)',
+    description:
+      'DEPRECATED: Use products_filters, assets_filters, or relationships_filters instead. Returns product search filters for backwards compatibility.',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const result = await client.getAvailableFilters();
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            deprecated: true,
+            message: 'Use products_filters, assets_filters, or relationships_filters instead.',
+            filters: result.data,
+            count: result.data?.length ?? 0,
+          }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching filters: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ─────────────────────────────────────────────────────────────
+// products_filters - Product search filter discovery
+// ─────────────────────────────────────────────────────────────
+
+registerTool<Record<string, never>>(
+  server,
+  'products_filters',
+  {
+    title: 'Product Search Filters',
+    description: 'Get available product search filter fields, types, and operators.',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const result = await client.getAvailableFilters();
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ resource: 'products', filters: result.data, count: result.data?.length ?? 0 }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching product filters: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ─────────────────────────────────────────────────────────────
+// assets_filters - Asset search filter discovery
+// ─────────────────────────────────────────────────────────────
+
+registerTool<Record<string, never>>(
+  server,
+  'assets_filters',
+  {
+    title: 'Asset Search Filters',
+    description: 'Get available asset search filter fields, types, and operators.',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const result = await client.getAssetFilters();
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ resource: 'assets', filters: result.data, count: result.data?.length ?? 0 }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching asset filters: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ─────────────────────────────────────────────────────────────
+// relationships_filters - Relationship search filter discovery
+// ─────────────────────────────────────────────────────────────
+
+registerTool<Record<string, never>>(
+  server,
+  'relationships_filters',
+  {
+    title: 'Relationship Search Filters',
+    description: 'Get available relationship search filter fields, types, and operators.',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const result = await client.getRelationshipFilters();
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ resource: 'relationships', filters: result.data, count: result.data?.length ?? 0 }, null, 2),
+        }],
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error fetching relationship filters: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/tools/attributes.ts
+git commit -m "feat: deprecate attributes_filters, add products_filters/assets_filters/relationships_filters"
+```
+
+---
+
+## Phase 7: Worker Parity — Variant + Asset Tools
+
+### Task 21: Add variant lifecycle tool definitions to worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Add `variants_create`, `variants_link`, `variants_unlink` tool definitions and handlers**
+
+Follow the existing worker pattern: add a `ToolDefinition` entry with JSON Schema `inputSchema`, and a handler that calls `WorkerPlytixClient` methods. Match the response shapes from the stdio tools.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/worker.ts
+git commit -m "feat: add variant lifecycle tools to worker runtime"
+```
+
+### Task 22: Add asset operation tool definitions to worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Add `assets_get`, `assets_search`, `assets_update` tool definitions and handlers**
+
+Ensure `assets_update` handler enforces the same filename+categories-only restriction.
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/worker.ts
+git commit -m "feat: add asset operation tools to worker runtime"
+```
+
+---
+
+## Phase 8: Worker Parity — Category, Relationship, Family Tools
+
+### Task 23: Add category search tool definition to worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Add `categories_search` tool definition and handler**
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/worker.ts
+git commit -m "feat: add categories_search tool to worker runtime"
+```
+
+### Task 24: Add relationship discovery tool definitions to worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Add `relationships_get`, `relationships_search` tool definitions and handlers**
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/worker.ts
+git commit -m "feat: add relationship discovery tools to worker runtime"
+```
+
+### Task 25: Add family operation tool definitions to worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Add `families_create`, `families_link_attribute`, `families_unlink_attribute`, `families_list_attributes`, `families_list_all_attributes` tool definitions and handlers**
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/worker.ts
+git commit -m "feat: add family operation tools to worker runtime"
+```
+
+---
+
+## Phase 9: Worker Parity — Filter Discovery Split
+
+### Task 26: Deprecate + replace filter tools in worker.ts
+
+**Files:**
+- Modify: `src/worker.ts`
+
+- [ ] **Step 1: Mark existing `attributes_filters` as deprecated in worker, add `products_filters`, `assets_filters`, `relationships_filters`**
+
+Keep `attributes_filters` handler with deprecation notice in response (same as stdio).
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/worker.ts
+git commit -m "feat: deprecate attributes_filters, add split filter tools to worker runtime"
+```
+
+---
+
+## Phase 10: Build + Integration Verification
+
+### Task 27: Full build
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build`
+Expected: Clean build, no errors
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `npm test -- --run`
+Expected: All existing tests pass
+
+### Task 28: MCP handshake verification
+
+- [ ] **Step 1: Run MCP handshake test**
+
+Run: `npm run test:mcp`
+Expected: All tools listed including new ones
+
+- [ ] **Step 2: Verify tool count**
+
+Stdio runtime should list ~49 tools:
+- 30 existing (including deprecated `attributes_filters`)
+- +3 variant tools
+- +3 asset tools
+- +1 category tool
+- +2 relationship tools
+- +7 family tools (create + link_attr + unlink_attr + list_attrs + list_all_attrs + ... wait, 5 not 7)
+- +3 filter tools
+
+Corrected: 30 existing + 17 new = 47 stdio tools (keeping deprecated `attributes_filters`).
+
+Worker runtime: 27 existing + 17 new = 44 worker tools.
+
+### Task 29: Run full test suite
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npm run test:all`
+Expected: All pass (build + unit + integration + MCP)
+
+---
+
+## Phase 11: Documentation Update
+
+### Task 30: Update CLAUDE.md tool tables
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add new tools to Read Operations table**
+
+Add: `assets_get`, `assets_search`, `categories_search`, `relationships_get`, `relationships_search`, `families_list_attributes`, `families_list_all_attributes`, `products_filters`, `assets_filters`, `relationships_filters`
+
+- [ ] **Step 2: Add new tools to Write Operations table**
+
+Add: `variants_create`, `variants_link`, `variants_unlink`, `assets_update`, `families_create`, `families_link_attribute`, `families_unlink_attribute`
+
+- [ ] **Step 3: Mark `attributes_filters` as deprecated in the table**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with new MCP tool surface"
+```
+
+---
+
+## Deprecated Tools
+
+| Old Tool | Status | Replacement |
+|----------|--------|------------|
+| `attributes_filters` | Deprecated (kept for backwards compat) | `products_filters` |
+
+## New Tools Summary (17)
+
+| Tool | Type | Phase |
+|------|------|-------|
+| `variants_create` | Write | 2 |
+| `variants_link` | Write | 2 |
+| `variants_unlink` | Write | 2 |
+| `assets_get` | Read | 3 |
+| `assets_search` | Read | 3 |
+| `assets_update` | Write | 3 |
+| `categories_search` | Read | 4 |
+| `relationships_get` | Read | 4 |
+| `relationships_search` | Read | 4 |
+| `families_create` | Write | 5 |
+| `families_link_attribute` | Write | 5 |
+| `families_unlink_attribute` | Write | 5 |
+| `families_list_attributes` | Read | 5 |
+| `families_list_all_attributes` | Read | 5 |
+| `products_filters` | Read | 6 |
+| `assets_filters` | Read | 6 |
+| `relationships_filters` | Read | 6 |
+
+## Safety Guardrails
+
+| Guardrail | Enforcement |
+|-----------|------------|
+| No product delete | No `products_delete` tool exists |
+| No asset binary ops | `assets_update` restricted to `filename` + `categories` only |
+| No category admin | Only search + link/unlink; no create/update/delete |
+| No relationship def CRUD | Only get + search; no create/update/delete |
+| No family delete | No `families_delete` tool exists |
+| No attribute schema mutation | No `attributes_update` tool exists |
+| No account admin | No auth/membership tools exposed |
+| Variant unlink ≠ delete | `variants_unlink` detaches without deleting the product |
+| Filter deprecation | `attributes_filters` kept as deprecated alias, not removed |
+
+## Unverified API Endpoints
+
+These endpoints come from the spec and should be manually verified before implementation:
+
+| Endpoint | Tool | Concern |
+|----------|------|---------|
+| `POST /api/v1/products/{id}/variant/{id}` | `variants_link` | Singular `/variant/` vs plural `/variants` |
+| `DELETE /api/v1/products/{id}/variant/{id}` | `variants_unlink` | Same singular/plural concern |
+| `POST /api/v1/categories/product/search` | `categories_search` | Standalone category search path unverified |
+| `GET /api/v1/relationships/{id}` | `relationships_get` | Standalone relationship def endpoint unverified |
+| `POST /api/v1/relationships/search` | `relationships_search` | Same |
+| `GET /api/v1/assets/search/filters` | `assets_filters` | Parallel to product filters, unverified |
+| `GET /api/v1/relationships/search/filters` | `relationships_filters` | Same |

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,8 +20,10 @@ import type {
   PlytixAsset,
   PlytixCategory,
   PlytixFamily,
+  PlytixFamilyAttribute,
   PlytixFilterDefinition,
   PlytixAttributeDetail,
+  PlytixRelationshipDefinition,
   RateLimitInfo,
 } from './types.js';
 import { PlytixError } from './types.js';
@@ -258,12 +260,68 @@ export class PlytixClient {
     );
   }
 
+  async createFamily(data: {
+    name: string;
+    parent_id?: string;
+  }): Promise<PlytixResult<PlytixFamily>> {
+    return this.request<PlytixFamily>('/api/v1/product_families', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async linkFamilyAttributes(
+    familyId: string,
+    attributeLabels: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/link`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ attributes: attributeLabels }),
+      }
+    );
+  }
+
+  async unlinkFamilyAttributes(
+    familyId: string,
+    attributeLabels: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/unlink`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ attributes: attributeLabels }),
+      }
+    );
+  }
+
+  async getFamilyAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+    return this.request<PlytixFamilyAttribute>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes`
+    );
+  }
+
+  async getFamilyAllAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+    return this.request<PlytixFamilyAttribute>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/all_attributes`
+    );
+  }
+
   // ─────────────────────────────────────────────────────────────
   // Attributes & Filters
   // ─────────────────────────────────────────────────────────────
 
   async getAvailableFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
-    return this.request<PlytixFilterDefinition>('/api/v1/products/search/filters');
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/product');
+  }
+
+  async getAssetFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/asset');
+  }
+
+  async getRelationshipFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/relationships');
   }
 
   /**
@@ -278,11 +336,12 @@ export class PlytixClient {
 
       if (filtersResult.data) {
         for (const filter of filtersResult.data) {
-          if (filter.field) {
-            if (filter.field.startsWith('attributes.')) {
+          const field = filter.key ?? filter.field;
+          if (field) {
+            if (field.startsWith('attributes.')) {
               custom.push(filter);
             } else {
-              system.push(filter.field);
+              system.push(field);
             }
           }
         }
@@ -385,13 +444,40 @@ export class PlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
-  // Assets (v2 API)
+  // Assets (v1 API for account-level asset discovery and metadata)
   // ─────────────────────────────────────────────────────────────
 
   async searchAssets(body?: PlytixSearchBody): Promise<PlytixResult<PlytixAsset>> {
-    return this.request<PlytixAsset>('/api/v2/assets/search', {
+    return this.request<PlytixAsset>('/api/v1/assets/search', {
       method: 'POST',
       body: JSON.stringify(body ?? {}),
+    });
+  }
+
+  async getAsset(assetId: string): Promise<PlytixResult<PlytixAsset>> {
+    return this.request<PlytixAsset>(`/api/v1/assets/${encodeURIComponent(assetId)}`);
+  }
+
+  async updateAsset(
+    assetId: string,
+    data: { filename?: string; categories?: string[] }
+  ): Promise<PlytixResult<PlytixAsset>> {
+    const body: {
+      filename?: string;
+      categories?: Array<{ id: string }>;
+    } = {};
+
+    if (data.filename !== undefined) {
+      body.filename = data.filename;
+    }
+
+    if (data.categories !== undefined) {
+      body.categories = data.categories.map((id) => ({ id }));
+    }
+
+    return this.request<PlytixAsset>(`/api/v1/assets/${encodeURIComponent(assetId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
     });
   }
 
@@ -515,6 +601,30 @@ export class PlytixClient {
     );
   }
 
+  async searchCategories(body?: PlytixSearchBody): Promise<PlytixResult<PlytixCategory>> {
+    return this.request<PlytixCategory>('/api/v1/categories/product/search', {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    });
+  }
+
+  async getRelationship(
+    relationshipId: string
+  ): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+    return this.request<PlytixRelationshipDefinition>(
+      `/api/v1/relationships/${encodeURIComponent(relationshipId)}`
+    );
+  }
+
+  async searchRelationships(
+    body?: PlytixSearchBody
+  ): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+    return this.request<PlytixRelationshipDefinition>('/api/v1/relationships/search', {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    });
+  }
+
   /**
    * Add related products to a relationship for a product.
    */
@@ -573,8 +683,41 @@ export class PlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
-  // Variants (v1 API - write operations)
+  // Variants
   // ─────────────────────────────────────────────────────────────
+
+  async createVariant(
+    parentProductId: string,
+    data: { sku: string; label?: string; attributes?: Record<string, unknown> }
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variants`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ variant: data }),
+      }
+    );
+  }
+
+  async linkVariant(
+    parentProductId: string,
+    variantProductId: string
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+      { method: 'POST' }
+    );
+  }
+
+  async unlinkVariant(
+    parentProductId: string,
+    variantProductId: string
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+      { method: 'DELETE' }
+    );
+  }
 
   /**
    * Resync variant attributes to inherit values from the parent product.
@@ -590,7 +733,7 @@ export class PlytixClient {
     variantIds: string[]
   ): Promise<PlytixResult<void>> {
     return this.request<void>(
-      `/api/v1/products/${encodeURIComponent(parentProductId)}/variants/resync`,
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variants/resync`,
       {
         method: 'POST',
         body: JSON.stringify({

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -7,16 +7,208 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
+import type { FilterOperator } from '../types.js';
 import { registerTool } from './register.js';
 
+const filterOperatorSchema = z.enum([
+  'eq',
+  '!eq',
+  'like',
+  'in',
+  '!in',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'exists',
+  '!exists',
+  'text_search',
+]);
+
 export function registerAssetTools(server: McpServer, client: PlytixClient) {
+  // GET single asset by ID
+  registerTool<{ asset_id: string }>(
+    server,
+    'assets_get',
+    {
+      title: 'Get Asset',
+      description: 'Get one asset by ID.',
+      inputSchema: {
+        asset_id: z.string().min(1).describe('The asset ID'),
+      },
+    },
+    async ({ asset_id }) => {
+      try {
+        const result = await client.getAsset(asset_id);
+        const asset = result.data?.[0];
+
+        if (!asset) {
+          return {
+            content: [{ type: 'text', text: `Asset not found: ${asset_id}` }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(asset, null, 2) }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching asset: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // SEARCH assets
+  registerTool<{
+    filters?: Array<Array<{ field: string; operator: FilterOperator; value?: unknown }>>;
+    pagination?: { page?: number; page_size?: number; order?: string };
+    sort?: unknown;
+  }>(
+    server,
+    'assets_search',
+    {
+      title: 'Search Assets',
+      description: 'Search assets.',
+      inputSchema: {
+        filters: z
+          .array(
+            z.array(
+              z.object({
+                field: z.string(),
+                operator: filterOperatorSchema,
+                value: z.unknown().optional(),
+              })
+            )
+          )
+          .optional()
+          .describe('Search filters in Plytix OR-of-ANDs format'),
+        pagination: z
+          .object({
+            page: z.number().int().positive().optional(),
+            page_size: z.number().int().positive().max(100).optional(),
+            order: z.string().optional(),
+          })
+          .optional()
+          .describe('Pagination options'),
+        sort: z.unknown().optional().describe('Optional sort payload'),
+      },
+    },
+    async ({ filters, pagination, sort }) => {
+      try {
+        const result = await client.searchAssets({
+          ...(filters !== undefined ? { filters } : {}),
+          ...(pagination !== undefined ? { pagination } : {}),
+          ...(sort !== undefined ? { sort } : {}),
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  assets: result.data,
+                  pagination: result.pagination,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error searching assets: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // UPDATE asset metadata (filename and categories only)
+  registerTool<{ asset_id: string; filename?: string; categories?: string[] }>(
+    server,
+    'assets_update',
+    {
+      title: 'Update Asset',
+      description: 'Update asset filename or categories.',
+      inputSchema: {
+        asset_id: z.string().min(1).describe('The asset ID'),
+        filename: z.string().optional().describe('New filename for the asset'),
+        categories: z.array(z.string()).optional().describe('Category IDs to assign to the asset'),
+      },
+    },
+    async ({ asset_id, filename, categories }) => {
+      try {
+        if (filename === undefined && categories === undefined) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error updating asset: provide at least one of filename or categories',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        await client.updateAsset(asset_id, {
+          ...(filename !== undefined ? { filename } : {}),
+          ...(categories !== undefined ? { categories } : {}),
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'updated',
+                  asset_id,
+                  ...(filename !== undefined ? { filename } : {}),
+                  ...(categories !== undefined ? { categories } : {}),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error updating asset: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   // LIST product assets
   registerTool<{ product_id: string }>(
     server,
     'assets_list',
     {
       title: 'List Assets',
-      description: 'List assets linked to a product (Plytix v2)',
+      description: 'List assets linked to a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to fetch assets for'),
       },
@@ -47,8 +239,7 @@ export function registerAssetTools(server: McpServer, client: PlytixClient) {
     'assets_link',
     {
       title: 'Link Asset',
-      description:
-        'Link an existing asset to a product. Optionally target a specific media attribute.',
+      description: 'Link an asset to a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID'),
         asset_id: z.string().min(1).describe('The asset ID to link'),
@@ -100,7 +291,7 @@ export function registerAssetTools(server: McpServer, client: PlytixClient) {
     'assets_unlink',
     {
       title: 'Unlink Asset',
-      description: 'Remove an asset link from a product. The asset itself is not deleted.',
+      description: 'Unlink an asset from a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID'),
         asset_id: z.string().min(1).describe('The asset ID to unlink'),

--- a/src/tools/attributes.ts
+++ b/src/tools/attributes.ts
@@ -20,10 +20,7 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
     'attributes_list',
     {
       title: 'List Attributes',
-      description:
-        'List all available product attributes (system and custom). ' +
-        'Returns attribute keys, types, labels, and options for dropdown fields. ' +
-        'Use this to discover what attributes exist and their data types.',
+      description: 'List product attributes.',
       inputSchema: {
         include_options: z
           .boolean()
@@ -38,9 +35,9 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
         const result: Record<string, unknown> = {
           system_attributes: system,
           custom_attributes: custom.map((attr) => ({
-            key: attr.field,
+            key: attr.key ?? attr.field,
             label: attr.label,
-            type: attr.type,
+            type: attr.filter_type ?? attr.type,
             ...(include_options && attr.options ? { options: attr.options } : {}),
           })),
           summary: {
@@ -76,10 +73,7 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
     'attributes_get',
     {
       title: 'Get Attribute',
-      description:
-        'Get full details for a single attribute by its label (snake_case identifier like "head_material"). ' +
-        'Returns type, options (for dropdowns), groups, and other metadata. ' +
-        'Use this to inspect a specific attribute or get its allowed values.',
+      description: 'Get one attribute.',
       inputSchema: {
         label: z
           .string()
@@ -141,10 +135,7 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
     'attributes_get_options',
     {
       title: 'Get Attribute Options',
-      description:
-        'Get the allowed values (options) for a dropdown or multiselect attribute. ' +
-        'Returns an array of valid option strings. ' +
-        'Use this to validate enum values or sync options to external systems.',
+      description: 'List allowed values for an attribute.',
       inputSchema: {
         label: z
           .string()
@@ -193,18 +184,15 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
   );
 
   // ─────────────────────────────────────────────────────────────
-  // attributes.filters - Get available search filters
+  // attributes.filters - Deprecated alias for product search filters
   // ─────────────────────────────────────────────────────────────
 
   registerTool<Record<string, never>>(
     server,
     'attributes_filters',
     {
-      title: 'Get Search Filters',
-      description:
-        'Get all available search filters for product queries. ' +
-        'Returns filterable fields, their types, and available operators. ' +
-        'Use this to understand how to construct advanced search queries.',
+      title: 'Get Search Filters (Deprecated)',
+      description: 'Deprecated alias for product filters.',
       inputSchema: {},
     },
     async () => {
@@ -217,6 +205,10 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
               type: 'text',
               text: JSON.stringify(
                 {
+                  deprecated: true,
+                  message: 'Use products_filters, assets_filters, or relationships_filters instead.',
+                  replacement_tools: ['products_filters', 'assets_filters', 'relationships_filters'],
+                  resource: 'products',
                   filters: result.data,
                   count: result.data?.length ?? 0,
                 },
@@ -232,6 +224,144 @@ export function registerAttributeTools(server: McpServer, client: PlytixClient) 
             {
               type: 'text',
               text: `Error fetching filters: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products_filters - Product filter discovery
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<Record<string, never>>(
+    server,
+    'products_filters',
+    {
+      title: 'Product Search Filters',
+      description: 'List product search filters.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await client.getAvailableFilters();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  resource: 'products',
+                  filters: result.data,
+                  count: result.data?.length ?? 0,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching product filters: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // assets_filters - Asset filter discovery
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<Record<string, never>>(
+    server,
+    'assets_filters',
+    {
+      title: 'Asset Search Filters',
+      description: 'List asset search filters.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await client.getAssetFilters();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  resource: 'assets',
+                  filters: result.data,
+                  count: result.data?.length ?? 0,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching asset filters: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // relationships_filters - Relationship filter discovery
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<Record<string, never>>(
+    server,
+    'relationships_filters',
+    {
+      title: 'Relationship Search Filters',
+      description: 'List relationship search filters.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await client.getRelationshipFilters();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  resource: 'relationships',
+                  filters: result.data,
+                  count: result.data?.length ?? 0,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching relationship filters: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
           isError: true,

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -10,13 +10,67 @@ import type { PlytixClient } from '../client.js';
 import { registerTool } from './register.js';
 
 export function registerCategoryTools(server: McpServer, client: PlytixClient) {
+  // SEARCH categories
+  registerTool<{ query?: string; pagination?: { page?: number; page_size?: number } }>(
+    server,
+    'categories_search',
+    {
+      title: 'Search Categories',
+      description: 'Search product categories.',
+      inputSchema: {
+        query: z.string().optional().describe('Search query to filter categories by name'),
+        pagination: z
+          .object({
+            page: z.number().int().positive().optional(),
+            page_size: z.number().int().positive().max(100).optional(),
+          })
+          .optional()
+          .describe('Pagination options'),
+      },
+    },
+    async ({ query, pagination }) => {
+      try {
+        const result = await client.searchCategories({
+          ...(pagination !== undefined ? { pagination } : {}),
+          ...(query ? { filters: [[{ field: 'name', operator: 'like', value: query }]] } : {}),
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  categories: result.data,
+                  pagination: result.pagination,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error searching categories: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   // LIST product categories
   registerTool<{ product_id: string }>(
     server,
     'categories_list',
     {
       title: 'List Categories',
-      description: 'List categories linked to a product (Plytix v2)',
+      description: 'List categories linked to a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to fetch categories for'),
       },
@@ -47,7 +101,7 @@ export function registerCategoryTools(server: McpServer, client: PlytixClient) {
     'categories_link',
     {
       title: 'Link Category',
-      description: 'Link an existing category to a product',
+      description: 'Link a category to a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID'),
         category_id: z.string().min(1).describe('The category ID to link'),
@@ -96,7 +150,7 @@ export function registerCategoryTools(server: McpServer, client: PlytixClient) {
     'categories_unlink',
     {
       title: 'Unlink Category',
-      description: 'Remove a category link from a product. The category itself is not deleted.',
+      description: 'Unlink a category from a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID'),
         category_id: z.string().min(1).describe('The category ID to unlink'),

--- a/src/tools/families.ts
+++ b/src/tools/families.ts
@@ -20,9 +20,7 @@ export function registerFamilyTools(server: McpServer, client: PlytixClient) {
     'families_list',
     {
       title: 'List Product Families',
-      description:
-        'List or search product families. Returns family IDs, names, and linked attributes. ' +
-        'Use this to understand the family structure for inheritance tracking.',
+      description: 'List product families.',
       inputSchema: {
         query: z.string().optional().describe('Search query to filter families by name'),
         page: z.number().int().positive().default(1).describe('Page number'),
@@ -79,9 +77,7 @@ export function registerFamilyTools(server: McpServer, client: PlytixClient) {
     'families_get',
     {
       title: 'Get Product Family',
-      description:
-        'Get a single product family by ID. Returns the family name, linked attributes, ' +
-        'and parent family (if any) for understanding inheritance.',
+      description: 'Get one product family.',
       inputSchema: {
         family_id: z.string().min(1).describe('The product family ID'),
       },
@@ -106,6 +102,263 @@ export function registerFamilyTools(server: McpServer, client: PlytixClient) {
             {
               type: 'text',
               text: `Error fetching family: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // families_create - Create a product family
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ name: string; parent_id?: string }>(
+    server,
+    'families_create',
+    {
+      title: 'Create Product Family',
+      description: 'Create a product family.',
+      inputSchema: {
+        name: z.string().min(1).describe('Name for the new family'),
+        parent_id: z.string().optional().describe('Optional parent family ID'),
+      },
+    },
+    async ({ name, parent_id }) => {
+      try {
+        const result = await client.createFamily({
+          name,
+          ...(parent_id !== undefined ? { parent_id } : {}),
+        });
+        const family = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'created',
+                  family: family ? { id: family.id, name: family.name } : undefined,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error creating family: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // families_link_attribute - Link one or more attributes
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ family_id: string; attribute_labels: string[] }>(
+    server,
+    'families_link_attribute',
+    {
+      title: 'Link Attributes to Family',
+      description: 'Link attributes to a family.',
+      inputSchema: {
+        family_id: z.string().min(1).describe('The product family ID'),
+        attribute_labels: z
+          .array(z.string())
+          .min(1)
+          .describe('Attribute labels to link to the family'),
+      },
+    },
+    async ({ family_id, attribute_labels }) => {
+      try {
+        await client.linkFamilyAttributes(family_id, attribute_labels);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'linked',
+                  family_id,
+                  attribute_labels,
+                  count: attribute_labels.length,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error linking family attributes: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // families_unlink_attribute - Unlink one or more attributes
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ family_id: string; attribute_labels: string[] }>(
+    server,
+    'families_unlink_attribute',
+    {
+      title: 'Unlink Attributes from Family',
+      description: 'Unlink attributes from a family.',
+      inputSchema: {
+        family_id: z.string().min(1).describe('The product family ID'),
+        attribute_labels: z
+          .array(z.string())
+          .min(1)
+          .describe('Attribute labels to unlink from the family'),
+      },
+    },
+    async ({ family_id, attribute_labels }) => {
+      try {
+        await client.unlinkFamilyAttributes(family_id, attribute_labels);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'unlinked',
+                  family_id,
+                  attribute_labels,
+                  count: attribute_labels.length,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error unlinking family attributes: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // families_list_attributes - Directly linked family attributes
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ family_id: string }>(
+    server,
+    'families_list_attributes',
+    {
+      title: 'List Family Attributes',
+      description: 'List direct family attributes.',
+      inputSchema: {
+        family_id: z.string().min(1).describe('The product family ID'),
+      },
+    },
+    async ({ family_id }) => {
+      try {
+        const result = await client.getFamilyAttributes(family_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  family_id,
+                  attributes: result.data,
+                  count: result.data?.length ?? 0,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error listing family attributes: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // families_list_all_attributes - Direct + inherited family attributes
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ family_id: string }>(
+    server,
+    'families_list_all_attributes',
+    {
+      title: 'List All Family Attributes',
+      description: 'List all family attributes.',
+      inputSchema: {
+        family_id: z.string().min(1).describe('The product family ID'),
+      },
+    },
+    async ({ family_id }) => {
+      try {
+        const result = await client.getFamilyAllAttributes(family_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  family_id,
+                  attributes: result.data,
+                  count: result.data?.length ?? 0,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error listing all family attributes: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
           isError: true,

--- a/src/tools/identifier.ts
+++ b/src/tools/identifier.ts
@@ -36,10 +36,7 @@ export function registerIdentifierTools(server: McpServer) {
     'identifier_detect',
     {
       title: 'Detect Identifier Type',
-      description:
-        'Detect the type of a product identifier based on format patterns. ' +
-        'Returns type (id, sku, mpn, mno, gtin, label) with confidence score. ' +
-        'Use this to understand what kind of identifier you have before searching.',
+      description: 'Detect identifier type.',
       inputSchema: {
         value: z.string().describe('The identifier value to analyze'),
       },
@@ -76,10 +73,7 @@ export function registerIdentifierTools(server: McpServer) {
     'identifier_normalize',
     {
       title: 'Normalize Identifier',
-      description:
-        'Normalize a product identifier for comparison by removing special ' +
-        'characters and converting to uppercase. Use this when comparing ' +
-        'identifiers that may have different formatting.',
+      description: 'Normalize an identifier.',
       inputSchema: {
         value: z.string().describe('The identifier value to normalize'),
       },
@@ -114,10 +108,7 @@ export function registerIdentifierTools(server: McpServer) {
     'match_score',
     {
       title: 'Score Match',
-      description:
-        'Calculate match confidence between an identifier and product data. ' +
-        'Checks common fields (sku, label, gtin, mpn) and returns the best match. ' +
-        'Use this to verify if a product is a good match for an identifier.',
+      description: 'Score an identifier against product data.',
       inputSchema: {
         identifier: z.string().describe('The identifier to match'),
         product_data: z

--- a/src/tools/product-attributes.ts
+++ b/src/tools/product-attributes.ts
@@ -20,9 +20,7 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
     'products_set_attribute',
     {
       title: 'Set Product Attribute',
-      description:
-        'Set a single product attribute value atomically. ' +
-        'Use snake_case labels (e.g., "head_material"). The "attributes." prefix is optional.',
+      description: 'Set one product attribute.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to update'),
         attribute_label: z
@@ -111,9 +109,7 @@ export function registerProductAttributeTools(server: McpServer, client: PlytixC
     'products_clear_attribute',
     {
       title: 'Clear Product Attribute',
-      description:
-        'Clear a single product attribute value atomically by setting it to null. ' +
-        'Use snake_case labels (e.g., "head_material"). The "attributes." prefix is optional.',
+      description: 'Clear one product attribute.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to update'),
         attribute_label: z

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -25,12 +25,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_lookup',
     {
       title: 'Smart Product Lookup',
-      description:
-        'Smart product lookup that auto-detects identifier type (ID, SKU, MPN, GTIN, label). ' +
-        'Uses staged search strategies with confidence scoring. ' +
-        'Returns the best match along with the search plan used. ' +
-        'MPN/MNO searches use PLYTIX_MPN_LABELS / PLYTIX_MNO_LABELS (defaults to attributes.mpn/model_no). ' +
-        'Includes overwritten_attributes to show which values are inherited vs explicitly set.',
+      description: 'Find the best product match for an identifier.',
       inputSchema: {
         identifier: z.string().min(1).describe('Product identifier (ID, SKU, MPN, GTIN, or label)'),
         type: z
@@ -110,10 +105,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_get',
     {
       title: 'Get Product',
-      description:
-        'Get a single product by ID. Returns full product data including ' +
-        'overwritten_attributes (attributes explicitly set, not inherited from family), ' +
-        'product_family_id, and product_type (PARENT/VARIANT/STANDALONE).',
+      description: 'Get one product by ID.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to fetch'),
       },
@@ -160,10 +152,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_search',
     {
       title: 'Search Products',
-      description:
-        'Search products with filters, pagination, and sorting. ' +
-        'Use attributes.filters tool to discover available filter fields. ' +
-        'Custom attributes should be prefixed with "attributes." (e.g., "attributes.head_material").',
+      description: 'Search products with filters.',
       inputSchema: {
         attributes: z
           .array(z.string())
@@ -236,9 +225,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_find',
     {
       title: 'Find Products',
-      description:
-        'Find products by multiple criteria (SKU, MPN, MNO, GTIN, label, or fuzzy search). ' +
-        'Simpler than products.search - just specify the fields you know.',
+      description: 'Find products by common identifiers.',
       inputSchema: {
         sku: z.string().optional().describe('Exact SKU match'),
         mpn: z.string().optional().describe('Manufacturer part number'),
@@ -320,9 +307,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_create',
     {
       title: 'Create Product',
-      description:
-        'Create a new product. Only SKU is required. ' +
-        'Cannot create new attributes/categories/assets - must link existing ones by ID.',
+      description: 'Create a product.',
       inputSchema: {
         sku: z.string().min(1).describe('Product SKU (required, must be unique)'),
         label: z.string().optional().describe('Product label/name'),
@@ -403,9 +388,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_update',
     {
       title: 'Update Product',
-      description:
-        'Update a product. Partial update - only specified fields are changed. ' +
-        'Set an attribute value to null to clear it.',
+      description: 'Update a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to update'),
         label: z.string().optional().describe('New product label/name'),
@@ -481,9 +464,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_assign_family',
     {
       title: 'Assign Product Family',
-      description:
-        'Assign a product family to a product. Pass empty string to unassign. ' +
-        'WARNING: Changing family may cause data loss. Cannot assign to variant products.',
+      description: 'Assign or unassign a family.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID'),
         family_id: z

--- a/src/tools/relationships.ts
+++ b/src/tools/relationships.ts
@@ -11,6 +11,106 @@ import { registerTool } from './register.js';
 
 export function registerRelationshipTools(server: McpServer, client: PlytixClient) {
   // ─────────────────────────────────────────────────────────────
+  // relationships_get - Get one relationship definition
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ relationship_id: string }>(
+    server,
+    'relationships_get',
+    {
+      title: 'Get Relationship',
+      description: 'Get one relationship definition.',
+      inputSchema: {
+        relationship_id: z.string().min(1).describe('The relationship definition ID'),
+      },
+    },
+    async ({ relationship_id }) => {
+      try {
+        const result = await client.getRelationship(relationship_id);
+        const relationship = result.data?.[0];
+
+        if (!relationship) {
+          return {
+            content: [{ type: 'text', text: `Relationship not found: ${relationship_id}` }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(relationship, null, 2) }],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching relationship: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // relationships_search - Search/list relationship definitions
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{ query?: string; pagination?: { page?: number; page_size?: number } }>(
+    server,
+    'relationships_search',
+    {
+      title: 'Search Relationships',
+      description: 'Search relationship definitions.',
+      inputSchema: {
+        query: z.string().optional().describe('Search query to filter relationships by label'),
+        pagination: z
+          .object({
+            page: z.number().int().positive().optional(),
+            page_size: z.number().int().positive().max(100).optional(),
+          })
+          .optional()
+          .describe('Pagination options'),
+      },
+    },
+    async ({ query, pagination }) => {
+      try {
+        const result = await client.searchRelationships({
+          ...(pagination !== undefined ? { pagination } : {}),
+          ...(query ? { filters: [[{ field: 'label', operator: 'like', value: query }]] } : {}),
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  relationships: result.data,
+                  pagination: result.pagination,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error searching relationships: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
   // relationships_link_product - Link one related product
   // ─────────────────────────────────────────────────────────────
 
@@ -24,9 +124,7 @@ export function registerRelationshipTools(server: McpServer, client: PlytixClien
     'relationships_link_product',
     {
       title: 'Link Related Product',
-      description:
-        'Link one product to another under a specific relationship. ' +
-        'If quantity is provided, it is stored in the relationship row.',
+      description: 'Link a related product.',
       inputSchema: {
         product_id: z.string().min(1).describe('Primary product ID'),
         relationship_id: z.string().min(1).describe('Relationship definition ID'),
@@ -89,8 +187,7 @@ export function registerRelationshipTools(server: McpServer, client: PlytixClien
     'relationships_unlink_product',
     {
       title: 'Unlink Related Product',
-      description:
-        'Unlink one related product from a relationship on the primary product.',
+      description: 'Unlink a related product.',
       inputSchema: {
         product_id: z.string().min(1).describe('Primary product ID'),
         relationship_id: z.string().min(1).describe('Relationship definition ID'),

--- a/src/tools/variants.ts
+++ b/src/tools/variants.ts
@@ -16,7 +16,7 @@ export function registerVariantTools(server: McpServer, client: PlytixClient) {
     'variants_list',
     {
       title: 'List Variants',
-      description: 'List variants linked to a product (Plytix v2)',
+      description: 'List variants for a product.',
       inputSchema: {
         product_id: z.string().min(1).describe('The product ID to fetch variants for'),
       },
@@ -47,9 +47,7 @@ export function registerVariantTools(server: McpServer, client: PlytixClient) {
     'variants_resync',
     {
       title: 'Resync Variants',
-      description:
-        'Resync variant attributes to inherit values from the parent product. ' +
-        'Restores overwritten attributes on specified variants to use the parent\'s value instead.',
+      description: 'Resync variant inheritance from the parent.',
       inputSchema: {
         parent_product_id: z.string().min(1).describe('The parent product ID containing the variants'),
         attribute_labels: z
@@ -88,6 +86,167 @@ export function registerVariantTools(server: McpServer, client: PlytixClient) {
             {
               type: 'text',
               text: `Error resyncing variants: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // CREATE variant under parent
+  registerTool<{
+    parent_product_id: string;
+    sku: string;
+    label?: string;
+    attributes?: Record<string, unknown>;
+  }>(
+    server,
+    'variants_create',
+    {
+      title: 'Create Variant',
+      description: 'Create a variant under a parent product.',
+      inputSchema: {
+        parent_product_id: z.string().min(1).describe('The parent product ID'),
+        sku: z.string().min(1).describe('SKU for the new variant'),
+        label: z.string().optional().describe('Optional label for the new variant'),
+        attributes: z
+          .record(z.unknown())
+          .optional()
+          .describe('Optional attributes to set or override on the variant'),
+      },
+    },
+    async ({ parent_product_id, sku, label, attributes }) => {
+      try {
+        const result = await client.createVariant(parent_product_id, {
+          sku,
+          ...(label !== undefined ? { label } : {}),
+          ...(attributes !== undefined ? { attributes } : {}),
+        });
+        const variant = result.data?.[0];
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'created',
+                  parent_product_id,
+                  variant: variant
+                    ? { id: variant.id, sku: variant.sku, label: variant.label }
+                    : undefined,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error creating variant: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // LINK existing product as variant
+  registerTool<{ parent_product_id: string; variant_product_id: string }>(
+    server,
+    'variants_link',
+    {
+      title: 'Link Variant',
+      description: 'Link an existing product as a variant.',
+      inputSchema: {
+        parent_product_id: z.string().min(1).describe('The parent product ID'),
+        variant_product_id: z
+          .string()
+          .min(1)
+          .describe('The existing product ID to link as a variant'),
+      },
+    },
+    async ({ parent_product_id, variant_product_id }) => {
+      try {
+        await client.linkVariant(parent_product_id, variant_product_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'linked',
+                  parent_product_id,
+                  variant_product_id,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error linking variant: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // UNLINK variant from parent (product is not deleted)
+  registerTool<{ parent_product_id: string; variant_product_id: string }>(
+    server,
+    'variants_unlink',
+    {
+      title: 'Unlink Variant',
+      description: 'Unlink a variant from its parent.',
+      inputSchema: {
+        parent_product_id: z.string().min(1).describe('The parent product ID'),
+        variant_product_id: z.string().min(1).describe('The variant product ID to unlink'),
+      },
+    },
+    async ({ parent_product_id, variant_product_id }) => {
+      try {
+        await client.unlinkVariant(parent_product_id, variant_product_id);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  action: 'unlinked',
+                  parent_product_id,
+                  variant_product_id,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error unlinking variant: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
           isError: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,16 @@ export interface PlytixRelationship {
   }>;
 }
 
+export interface PlytixRelationshipDefinition {
+  id: string;
+  label: string;
+  name?: string;
+  symmetrical?: boolean;
+  created?: string;
+  modified?: string;
+  [key: string]: unknown;
+}
+
 // ─────────────────────────────────────────────────────────────
 // Families
 // ─────────────────────────────────────────────────────────────
@@ -131,6 +141,7 @@ export interface PlytixFamily {
 }
 
 export interface PlytixFamilyAttribute {
+  id?: string;
   label: string;          // e.g., "head_material" (snake_case identifier)
   name: string;           // e.g., "Head Material" (human-readable)
   type?: string;          // e.g., "dropdown", "text", "number"
@@ -139,6 +150,7 @@ export interface PlytixFamilyAttribute {
   inherited?: boolean;    // whether inherited from parent family
   default_value?: unknown;
   options?: unknown[];    // for dropdown/multiselect types
+  [key: string]: unknown;
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -206,10 +218,15 @@ export interface PlytixAttributeDetail {
 }
 
 export interface PlytixFilterDefinition {
-  field: string;
-  type: string;
+  key?: string;
+  field?: string;
+  type?: string;
+  filter_type?: string;
   label?: string;
+  name?: string;
+  operators?: FilterOperator[];
   options?: unknown[];
+  [key: string]: unknown;
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -19,7 +19,9 @@ import type {
   PlytixAsset,
   PlytixCategory,
   PlytixFamily,
+  PlytixFamilyAttribute,
   PlytixFilterDefinition,
+  PlytixRelationshipDefinition,
   RateLimitInfo,
 } from './types.js';
 import { PlytixError } from './types.js';
@@ -347,12 +349,68 @@ export class WorkerPlytixClient {
     );
   }
 
+  async createFamily(data: {
+    name: string;
+    parent_id?: string;
+  }): Promise<PlytixResult<PlytixFamily>> {
+    return this.request<PlytixFamily>('/api/v1/product_families', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async linkFamilyAttributes(
+    familyId: string,
+    attributeLabels: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/link`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ attributes: attributeLabels }),
+      }
+    );
+  }
+
+  async unlinkFamilyAttributes(
+    familyId: string,
+    attributeLabels: string[]
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes/unlink`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ attributes: attributeLabels }),
+      }
+    );
+  }
+
+  async getFamilyAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+    return this.request<PlytixFamilyAttribute>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/attributes`
+    );
+  }
+
+  async getFamilyAllAttributes(familyId: string): Promise<PlytixResult<PlytixFamilyAttribute>> {
+    return this.request<PlytixFamilyAttribute>(
+      `/api/v1/product_families/${encodeURIComponent(familyId)}/all_attributes`
+    );
+  }
+
   // ─────────────────────────────────────────────────────────────
   // Attributes & Filters
   // ─────────────────────────────────────────────────────────────
 
   async getAvailableFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
-    return this.request<PlytixFilterDefinition>('/api/v1/products/search/filters');
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/product');
+  }
+
+  async getAssetFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/asset');
+  }
+
+  async getRelationshipFilters(): Promise<PlytixResult<PlytixFilterDefinition>> {
+    return this.request<PlytixFilterDefinition>('/api/v1/filters/relationships');
   }
 
   async getProductAttributes(): Promise<{ system: string[]; custom: PlytixFilterDefinition[] }> {
@@ -364,11 +422,12 @@ export class WorkerPlytixClient {
 
       if (filtersResult.data) {
         for (const filter of filtersResult.data) {
-          if (filter.field) {
-            if (filter.field.startsWith('attributes.')) {
+          const field = filter.key ?? filter.field;
+          if (field) {
+            if (field.startsWith('attributes.')) {
               custom.push(filter);
             } else {
-              system.push(filter.field);
+              system.push(field);
             }
           }
         }
@@ -385,19 +444,103 @@ export class WorkerPlytixClient {
   }
 
   // ─────────────────────────────────────────────────────────────
-  // Assets (v2 API)
+  // Assets (v1 API for account-level asset discovery and metadata)
   // ─────────────────────────────────────────────────────────────
 
   async searchAssets(body?: PlytixSearchBody): Promise<PlytixResult<PlytixAsset>> {
-    return this.request<PlytixAsset>('/api/v2/assets/search', {
+    return this.request<PlytixAsset>('/api/v1/assets/search', {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    });
+  }
+
+  async getAsset(assetId: string): Promise<PlytixResult<PlytixAsset>> {
+    return this.request<PlytixAsset>(`/api/v1/assets/${encodeURIComponent(assetId)}`);
+  }
+
+  async updateAsset(
+    assetId: string,
+    data: { filename?: string; categories?: string[] }
+  ): Promise<PlytixResult<PlytixAsset>> {
+    const body: {
+      filename?: string;
+      categories?: Array<{ id: string }>;
+    } = {};
+
+    if (data.filename !== undefined) {
+      body.filename = data.filename;
+    }
+
+    if (data.categories !== undefined) {
+      body.categories = data.categories.map((id) => ({ id }));
+    }
+
+    return this.request<PlytixAsset>(`/api/v1/assets/${encodeURIComponent(assetId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+  }
+
+  async searchCategories(body?: PlytixSearchBody): Promise<PlytixResult<PlytixCategory>> {
+    return this.request<PlytixCategory>('/api/v1/categories/product/search', {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    });
+  }
+
+  async getRelationship(
+    relationshipId: string
+  ): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+    return this.request<PlytixRelationshipDefinition>(
+      `/api/v1/relationships/${encodeURIComponent(relationshipId)}`
+    );
+  }
+
+  async searchRelationships(
+    body?: PlytixSearchBody
+  ): Promise<PlytixResult<PlytixRelationshipDefinition>> {
+    return this.request<PlytixRelationshipDefinition>('/api/v1/relationships/search', {
       method: 'POST',
       body: JSON.stringify(body ?? {}),
     });
   }
 
   // ─────────────────────────────────────────────────────────────
-  // Variants (v1 API - write operations)
+  // Variants
   // ─────────────────────────────────────────────────────────────
+
+  async createVariant(
+    parentProductId: string,
+    data: { sku: string; label?: string; attributes?: Record<string, unknown> }
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variants`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ variant: data }),
+      }
+    );
+  }
+
+  async linkVariant(
+    parentProductId: string,
+    variantProductId: string
+  ): Promise<PlytixResult<PlytixProduct>> {
+    return this.request<PlytixProduct>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+      { method: 'POST' }
+    );
+  }
+
+  async unlinkVariant(
+    parentProductId: string,
+    variantProductId: string
+  ): Promise<PlytixResult<void>> {
+    return this.request<void>(
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variant/${encodeURIComponent(variantProductId)}`,
+      { method: 'DELETE' }
+    );
+  }
 
   async resyncVariants(
     parentProductId: string,
@@ -405,7 +548,7 @@ export class WorkerPlytixClient {
     variantIds: string[]
   ): Promise<PlytixResult<void>> {
     return this.request<void>(
-      `/api/v1/products/${encodeURIComponent(parentProductId)}/variants/resync`,
+      `/api/v2/products/${encodeURIComponent(parentProductId)}/variants/resync`,
       {
         method: 'POST',
         body: JSON.stringify({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -104,11 +104,7 @@ function normalizeAttributeLabel(label: string): string {
 const TOOLS: ToolDefinition[] = [
   {
     name: 'products_lookup',
-    description:
-      'Smart product lookup that auto-detects identifier type (ID, SKU, MPN, GTIN, label). ' +
-      'Uses staged search strategies with confidence scoring. ' +
-      'Returns the best match along with the search plan used. ' +
-      'MPN/MNO searches use attributes.mpn/model_no by default.',
+    description: 'Find the best product match for an identifier.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -132,9 +128,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_get',
-    description:
-      'Get a single product by ID. Returns full product data including ' +
-      'overwritten_attributes (attributes explicitly set, not inherited from family).',
+    description: 'Get one product by ID.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -148,9 +142,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_search',
-    description:
-      'Search products with filters, pagination, and sorting. ' +
-      'Custom attributes should be prefixed with "attributes." (e.g., "attributes.head_material").',
+    description: 'Search products with filters.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -178,9 +170,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_find',
-    description:
-      'Find products by multiple criteria (SKU, MPN, MNO, GTIN, label, or fuzzy search). ' +
-      'Simpler than products_search - just specify the fields you know.',
+    description: 'Find products by common identifiers.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -196,7 +186,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'families_list',
-    description: 'List or search product families. Returns family IDs, names, and linked attributes.',
+    description: 'List product families.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -208,7 +198,73 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'families_get',
-    description: 'Get a single product family by ID. Returns the family name and linked attributes.',
+    description: 'Get one product family.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        family_id: { type: 'string', description: 'The product family ID' },
+      },
+      required: ['family_id'],
+    },
+  },
+  {
+    name: 'families_create',
+    description: 'Create a product family.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name for the new family' },
+        parent_id: { type: 'string', description: 'Optional parent family ID' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'families_link_attribute',
+    description: 'Link attributes to a family.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        family_id: { type: 'string', description: 'The product family ID' },
+        attribute_labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Attribute labels to link to the family',
+        },
+      },
+      required: ['family_id', 'attribute_labels'],
+    },
+  },
+  {
+    name: 'families_unlink_attribute',
+    description: 'Unlink attributes from a family.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        family_id: { type: 'string', description: 'The product family ID' },
+        attribute_labels: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Attribute labels to unlink from the family',
+        },
+      },
+      required: ['family_id', 'attribute_labels'],
+    },
+  },
+  {
+    name: 'families_list_attributes',
+    description: 'List direct family attributes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        family_id: { type: 'string', description: 'The product family ID' },
+      },
+      required: ['family_id'],
+    },
+  },
+  {
+    name: 'families_list_all_attributes',
+    description: 'List all family attributes.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -219,9 +275,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'attributes_list',
-    description:
-      'List all available product attributes (system and custom). ' +
-      'Returns attribute keys, types, labels, and options for dropdown fields.',
+    description: 'List product attributes.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -235,7 +289,31 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'attributes_filters',
-    description: 'Get all available search filters for product queries.',
+    description: 'Deprecated alias for product filters.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'products_filters',
+    description: 'List product search filters.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'assets_filters',
+    description: 'List asset search filters.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'relationships_filters',
+    description: 'List relationship search filters.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -243,9 +321,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_set_attribute',
-    description:
-      'Set a single product attribute value atomically. ' +
-      'Use snake_case labels (e.g., "head_material").',
+    description: 'Set one product attribute.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -258,8 +334,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_clear_attribute',
-    description:
-      'Clear a single product attribute value atomically by setting it to null.',
+    description: 'Clear one product attribute.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -267,6 +342,56 @@ const TOOLS: ToolDefinition[] = [
         attribute_label: { type: 'string', description: 'Attribute label (snake_case)' },
       },
       required: ['product_id', 'attribute_label'],
+    },
+  },
+  {
+    name: 'assets_get',
+    description: 'Get one asset by ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        asset_id: { type: 'string', description: 'The asset ID' },
+      },
+      required: ['asset_id'],
+    },
+  },
+  {
+    name: 'assets_search',
+    description: 'Search assets.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        filters: {
+          type: 'array',
+          description: 'Search filters in Plytix OR-of-ANDs format',
+        },
+        pagination: {
+          type: 'object',
+          properties: {
+            page: { type: 'number' },
+            page_size: { type: 'number' },
+            order: { type: 'string' },
+          },
+        },
+        sort: { description: 'Optional sort payload' },
+      },
+    },
+  },
+  {
+    name: 'assets_update',
+    description: 'Update asset filename or categories.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        asset_id: { type: 'string', description: 'The asset ID' },
+        filename: { type: 'string', description: 'New filename for the asset' },
+        categories: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Category IDs to assign to the asset',
+        },
+      },
+      required: ['asset_id'],
     },
   },
   {
@@ -282,7 +407,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'assets_link',
-    description: 'Link an existing asset to a product.',
+    description: 'Link an asset to a product.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -309,6 +434,23 @@ const TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'categories_search',
+    description: 'Search product categories.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query to filter categories by name' },
+        pagination: {
+          type: 'object',
+          properties: {
+            page: { type: 'number' },
+            page_size: { type: 'number' },
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'categories_list',
     description: 'List categories linked to a product.',
     inputSchema: {
@@ -317,6 +459,47 @@ const TOOLS: ToolDefinition[] = [
         product_id: { type: 'string', description: 'The product ID' },
       },
       required: ['product_id'],
+    },
+  },
+  {
+    name: 'variants_create',
+    description: 'Create a variant under a parent product.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        parent_product_id: { type: 'string', description: 'The parent product ID' },
+        sku: { type: 'string', description: 'SKU for the new variant' },
+        label: { type: 'string', description: 'Optional label for the new variant' },
+        attributes: { description: 'Optional attributes to set or override on the variant' },
+      },
+      required: ['parent_product_id', 'sku'],
+    },
+  },
+  {
+    name: 'variants_link',
+    description: 'Link an existing product as a variant.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        parent_product_id: { type: 'string', description: 'The parent product ID' },
+        variant_product_id: {
+          type: 'string',
+          description: 'The existing product ID to link as a variant',
+        },
+      },
+      required: ['parent_product_id', 'variant_product_id'],
+    },
+  },
+  {
+    name: 'variants_unlink',
+    description: 'Unlink a variant from its parent.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        parent_product_id: { type: 'string', description: 'The parent product ID' },
+        variant_product_id: { type: 'string', description: 'The variant product ID to unlink' },
+      },
+      required: ['parent_product_id', 'variant_product_id'],
     },
   },
   {
@@ -332,9 +515,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'variants_resync',
-    description:
-      'Resync variant attributes to inherit values from the parent product. ' +
-      'Restores overwritten attributes on specified variants to use the parent\'s value instead.',
+    description: 'Resync variant inheritance from the parent.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -357,9 +538,36 @@ const TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: 'relationships_get',
+    description: 'Get one relationship definition.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        relationship_id: { type: 'string', description: 'The relationship definition ID' },
+      },
+      required: ['relationship_id'],
+    },
+  },
+  {
+    name: 'relationships_search',
+    description: 'Search relationship definitions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query to filter relationships by label' },
+        pagination: {
+          type: 'object',
+          properties: {
+            page: { type: 'number' },
+            page_size: { type: 'number' },
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'relationships_link_product',
-    description:
-      'Link one product to another under a specific relationship.',
+    description: 'Link a related product.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -373,8 +581,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'relationships_unlink_product',
-    description:
-      'Unlink one related product from a relationship on the primary product.',
+    description: 'Unlink a related product.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -387,8 +594,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'relationships_set_quantity',
-    description:
-      'Set quantity for a single related product row in a relationship.',
+    description: 'Set quantity on a related product row.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -589,6 +795,127 @@ const toolHandlers: Record<string, ToolHandler> = {
     };
   },
 
+  async families_create(args, client) {
+    const result = await client.createFamily({
+      name: args.name as string,
+      ...(args.parent_id !== undefined ? { parent_id: args.parent_id as string } : {}),
+    });
+    const family = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'created',
+              family: family ? { id: family.id, name: family.name } : undefined,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async families_link_attribute(args, client) {
+    const familyId = args.family_id as string;
+    const attributeLabels = args.attribute_labels as string[];
+
+    await client.linkFamilyAttributes(familyId, attributeLabels);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'linked',
+              family_id: familyId,
+              attribute_labels: attributeLabels,
+              count: attributeLabels.length,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async families_unlink_attribute(args, client) {
+    const familyId = args.family_id as string;
+    const attributeLabels = args.attribute_labels as string[];
+
+    await client.unlinkFamilyAttributes(familyId, attributeLabels);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'unlinked',
+              family_id: familyId,
+              attribute_labels: attributeLabels,
+              count: attributeLabels.length,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async families_list_attributes(args, client) {
+    const familyId = args.family_id as string;
+    const result = await client.getFamilyAttributes(familyId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              family_id: familyId,
+              attributes: result.data,
+              count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async families_list_all_attributes(args, client) {
+    const familyId = args.family_id as string;
+    const result = await client.getFamilyAllAttributes(familyId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              family_id: familyId,
+              attributes: result.data,
+              count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
   async attributes_list(args, client) {
     const { system, custom } = await client.getProductAttributes();
     const includeOptions = args.include_options !== false;
@@ -596,9 +923,9 @@ const toolHandlers: Record<string, ToolHandler> = {
     const result = {
       system_attributes: system,
       custom_attributes: custom.map((attr) => ({
-        key: attr.field,
+        key: attr.key ?? attr.field,
         label: attr.label,
-        type: attr.type,
+        type: attr.filter_type ?? attr.type,
         ...(includeOptions && attr.options ? { options: attr.options } : {}),
       })),
       summary: {
@@ -622,6 +949,73 @@ const toolHandlers: Record<string, ToolHandler> = {
           type: 'text',
           text: JSON.stringify(
             {
+              deprecated: true,
+              message: 'Use products_filters, assets_filters, or relationships_filters instead.',
+              replacement_tools: ['products_filters', 'assets_filters', 'relationships_filters'],
+              resource: 'products',
+              filters: result.data,
+              count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async products_filters(args, client) {
+    const result = await client.getAvailableFilters();
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              resource: 'products',
+              filters: result.data,
+              count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async assets_filters(args, client) {
+    const result = await client.getAssetFilters();
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              resource: 'assets',
+              filters: result.data,
+              count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async relationships_filters(args, client) {
+    const result = await client.getRelationshipFilters();
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              resource: 'relationships',
               filters: result.data,
               count: result.data?.length ?? 0,
             },
@@ -713,6 +1107,97 @@ const toolHandlers: Record<string, ToolHandler> = {
     };
   },
 
+  async assets_get(args, client) {
+    const assetId = args.asset_id as string;
+    const result = await client.getAsset(assetId);
+    const asset = result.data?.[0];
+
+    if (!asset) {
+      return {
+        content: [{ type: 'text', text: `Asset not found: ${assetId}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(asset, null, 2) }],
+    };
+  },
+
+  async assets_search(args, client) {
+    const body: Record<string, unknown> = {};
+
+    if (args.filters !== undefined) {
+      body.filters = args.filters;
+    }
+    if (args.pagination !== undefined) {
+      body.pagination = args.pagination;
+    }
+    if (args.sort !== undefined) {
+      body.sort = args.sort;
+    }
+
+    const result = await client.searchAssets(body);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              assets: result.data,
+              pagination: result.pagination,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async assets_update(args, client) {
+    const assetId = args.asset_id as string;
+    const filename = args.filename as string | undefined;
+    const categories = args.categories as string[] | undefined;
+
+    if (filename === undefined && categories === undefined) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'Error updating asset: provide at least one of filename or categories',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    await client.updateAsset(assetId, {
+      ...(filename !== undefined ? { filename } : {}),
+      ...(categories !== undefined ? { categories } : {}),
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'updated',
+              asset_id: assetId,
+              ...(filename !== undefined ? { filename } : {}),
+              ...(categories !== undefined ? { categories } : {}),
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
   async assets_list(args, client) {
     const productId = args.product_id as string;
     const result = await client.getProductAssets(productId);
@@ -786,6 +1271,35 @@ const toolHandlers: Record<string, ToolHandler> = {
     };
   },
 
+  async categories_search(args, client) {
+    const body: Record<string, unknown> = {};
+
+    if (args.pagination !== undefined) {
+      body.pagination = args.pagination;
+    }
+    if (args.query) {
+      body.filters = [[{ field: 'name', operator: 'like', value: args.query }]];
+    }
+
+    const result = await client.searchCategories(body);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              categories: result.data,
+              pagination: result.pagination,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
   async categories_list(args, client) {
     const productId = args.product_id as string;
     const result = await client.getProductCategories(productId);
@@ -798,6 +1312,86 @@ const toolHandlers: Record<string, ToolHandler> = {
             {
               categories: result.data,
               count: result.data?.length ?? 0,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async variants_create(args, client) {
+    const parentProductId = args.parent_product_id as string;
+    const result = await client.createVariant(parentProductId, {
+      sku: args.sku as string,
+      ...(args.label !== undefined ? { label: args.label as string } : {}),
+      ...(args.attributes !== undefined ? { attributes: args.attributes as Record<string, unknown> } : {}),
+    });
+    const variant = result.data?.[0];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'created',
+              parent_product_id: parentProductId,
+              variant: variant
+                ? { id: variant.id, sku: variant.sku, label: variant.label }
+                : undefined,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async variants_link(args, client) {
+    const parentProductId = args.parent_product_id as string;
+    const variantProductId = args.variant_product_id as string;
+
+    await client.linkVariant(parentProductId, variantProductId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'linked',
+              parent_product_id: parentProductId,
+              variant_product_id: variantProductId,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async variants_unlink(args, client) {
+    const parentProductId = args.parent_product_id as string;
+    const variantProductId = args.variant_product_id as string;
+
+    await client.unlinkVariant(parentProductId, variantProductId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              success: true,
+              action: 'unlinked',
+              parent_product_id: parentProductId,
+              variant_product_id: variantProductId,
             },
             null,
             2
@@ -845,6 +1439,52 @@ const toolHandlers: Record<string, ToolHandler> = {
               parent_product_id: parentProductId,
               attributes_reset: attributeLabels,
               variants_affected: variantIds.length,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  },
+
+  async relationships_get(args, client) {
+    const relationshipId = args.relationship_id as string;
+    const result = await client.getRelationship(relationshipId);
+    const relationship = result.data?.[0];
+
+    if (!relationship) {
+      return {
+        content: [{ type: 'text', text: `Relationship not found: ${relationshipId}` }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(relationship, null, 2) }],
+    };
+  },
+
+  async relationships_search(args, client) {
+    const body: Record<string, unknown> = {};
+
+    if (args.pagination !== undefined) {
+      body.pagination = args.pagination;
+    }
+    if (args.query) {
+      body.filters = [[{ field: 'label', operator: 'like', value: args.query }]];
+    }
+
+    const result = await client.searchRelationships(body);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              relationships: result.data,
+              pagination: result.pagination,
             },
             null,
             2

--- a/test-mcp-client.js
+++ b/test-mcp-client.js
@@ -85,13 +85,13 @@ const steps = [
     }
   },
   {
-    name: 'Test products.get (will fail without real credentials)',
+    name: 'Test products_get (will fail without real credentials)',
     message: {
       jsonrpc: '2.0',
       id: 3,
       method: 'tools/call',
       params: {
-        name: 'products.get',
+        name: 'products_get',
         arguments: {
           product_id: 'test-product-123'
         }


### PR DESCRIPTION
## Summary
- add the 17 requested Plytix MCP tools for variants, assets, categories, relationships, families, and split filter discovery
- keep stdio and worker runtimes in parity, including the deprecated attributes_filters alias
- trim MCP-facing tool descriptions so tools/list stays lean
- update local reference docs and the implementation plan used for this change

## Verification
- npm run typecheck
- npm run typecheck:worker
- npm run build
- npm test -- --run
- npm run test:mcp

## Notes
- implementation follows the local Plytix API reference docs added in this branch
- live endpoint behavior for the new API paths was not verified against a real Plytix account in this session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new write-capable tools (variants, family attribute membership, asset metadata updates) and changes several API endpoints/versions, so incorrect paths or payload assumptions could cause runtime failures or unintended catalog changes.
> 
> **Overview**
> Expands the Plytix MCP tool surface with **17 new tools** covering variant lifecycle (`variants_create/link/unlink`), account-level asset operations (`assets_get/search/update`), category search, relationship definition discovery (`relationships_get/search`), and richer family operations (create + link/unlink/list attributes, incl. inherited).
> 
> Updates both `client.ts` and `worker-client.ts` to add the required API methods and align endpoints (notably moving filter discovery to `/api/v1/filters/*`, assets search/get/update to v1, and variant operations/resync to v2), plus extends `types.ts` for relationship definitions and more flexible filter/attribute shapes. Documentation is refreshed (`CLAUDE.md`) and new Plytix API reference/snapshot + implementation plan docs are added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 254dcaff211cb41bcf5ee1c2207545d18e450845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->