### PR TITLE
v0.2.2 fix: address Codex review — byte-accurate body cap + unambiguous cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-31
+
+Follow-up fixes from post-merge code review. No breaking changes.
+
+### Security
+- The Worker request-body cap now measures UTF-8 byte length and checks `Content-Length`
+  up front, instead of `String.length` (UTF-16 code units). A multi-byte JSON payload could
+  previously exceed 256 KB on the wire while passing the character-count check.
+- The token-cache key now derives from `JSON.stringify([apiKey, apiPassword])` instead of
+  `` `${apiKey}:${apiPassword}` ``. The delimiter form was ambiguous — pairs like
+  `("a:b","c")` and `("a","b:c")` hashed identically, which could let one credential pair
+  reuse a token minted for another and undo the v0.2.1 cache-key hardening.
+
 ## [0.2.1] - 2026-05-31
 
 Security hardening, bug fixes, and public-readiness cleanup. No breaking changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plytix-mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "MCP server for Plytix PIM API integration. Enables AI assistants to read, write, and manage product data, assets, categories, and relationships.",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { registerIdentifierTools } from './tools/identifier.js';
 import { registerProductAttributeTools } from './tools/product-attributes.js';
 import { registerRelationshipTools } from './tools/relationships.js';
 
-const VERSION = '0.2.1';
+const VERSION = '0.2.2';
 
 function printUsage(): void {
   process.stdout.write(

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -46,9 +46,13 @@ const tokenInFlight = new Map<string, Promise<string>>();
  * Derives a non-reversible cache key from both credentials. Using a SHA-256 digest
  * avoids holding the plaintext api_password in a Map key while still scoping a cached
  * token to the exact credential pair.
+ *
+ * The pair is JSON-encoded (not joined with a delimiter) so the digest is unambiguous:
+ * a naive `${apiKey}:${apiPassword}` would collide for pairs like ("a:b","c") and
+ * ("a","b:c"), letting one credential pair reuse a token minted for another.
  */
 async function deriveCacheKey(apiKey: string, apiPassword: string): Promise<string> {
-  const data = new TextEncoder().encode(`${apiKey}:${apiPassword}`);
+  const data = new TextEncoder().encode(JSON.stringify([apiKey, apiPassword]));
   const digest = await crypto.subtle.digest('SHA-256', data);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, '0'))

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2145,7 +2145,7 @@ async function handleMcpRequest(
             },
             serverInfo: {
               name: 'plytix-mcp',
-              version: '0.2.1',
+              version: '0.2.2',
             },
           },
         };
@@ -2278,7 +2278,7 @@ export default {
       return new Response(
         JSON.stringify({
           name: 'plytix-mcp',
-          version: '0.2.1',
+          version: '0.2.2',
           description: 'Remote MCP server for Plytix PIM',
           endpoints: {
             mcp: '/mcp',
@@ -2307,19 +2307,32 @@ export default {
     // MCP endpoint
     if (url.pathname === '/mcp' && request.method === 'POST') {
       // Parse JSON-RPC request first to check if auth is needed
+      const MAX_BODY_BYTES = 256 * 1024;
+      const tooLargeResponse = () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32600, message: `Request body too large (max ${MAX_BODY_BYTES} bytes)` },
+          }),
+          { status: 413, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+
+      // Reject oversized payloads up front when Content-Length is present (avoids decoding
+      // the whole body just to reject it). Content-Length counts wire bytes, not characters.
+      const contentLength = Number(request.headers.get('Content-Length'));
+      if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+        return tooLargeResponse();
+      }
+
       let body: JsonRpcRequest | JsonRpcRequest[];
       let bodyText: string;
       try {
         bodyText = await request.text();
-        if (bodyText.length > 256 * 1024) {
-          return new Response(
-            JSON.stringify({
-              jsonrpc: '2.0',
-              id: null,
-              error: { code: -32600, message: 'Request body too large (max 262144 bytes)' },
-            }),
-            { status: 413, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
-          );
+        // Measure decoded body by UTF-8 byte length, not String.length (UTF-16 code units).
+        // A multi-byte payload can exceed the cap on the wire while String.length stays under it.
+        if (new TextEncoder().encode(bodyText).length > MAX_BODY_BYTES) {
+          return tooLargeResponse();
         }
         body = JSON.parse(bodyText);
       } catch {


### PR DESCRIPTION
## Summary

Two follow-up fixes from Codex review comments on #18 (both P2, both legitimate). No breaking changes.

### `src/worker.ts` — measure the body cap in bytes
The 256 KB request-body guard used `bodyText.length`, which counts UTF-16 code units **after** the body is already decoded. A JSON payload with multi-byte characters can be well over 256 KB on the wire while passing the character-count check, bypassing the cap.

**Fix:** check `Content-Length` up front (reject before decoding when present), and measure the decoded body by UTF-8 byte length (`new TextEncoder().encode(bodyText).length`) instead of `String.length`. Shared 413 response factored into one helper.

### `src/worker-client.ts` — make the credential digest unambiguous
The token-cache key hashed `` `${apiKey}:${apiPassword}` ``. That delimiter form is ambiguous: `("a:b","c")` and `("a","b:c")` both produce `a:b:c`, so two distinct credential pairs derive the same cache key — silently re-introducing the cross-credential token reuse the v0.2.1 cache-key change was meant to eliminate.

**Fix:** derive the key from `JSON.stringify([apiKey, apiPassword])`. JSON encoding is unambiguous, so distinct pairs always produce distinct digest inputs.

## Verification
- [x] `npm run typecheck` — 0 errors
- [x] `npm run typecheck:worker` — 0 errors
- [x] `npm test` (vitest) — 33/33 passed
- [x] `npm run build` — clean
- [x] `node dist/index.js --version` → 0.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)