### PR TITLE
test: fix stale worker auth assertion + add tools/call auth-boundary test

### DIFF
--- a/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
+++ b/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
@@ -1,0 +1,102 @@
+# "Could not attach to MCP server plytix" — transports, reboot flakiness, auth
+
+_Diagnosed 2026-06-01._
+
+## TL;DR
+
+A "Could not attach to MCP server plytix" toast after a reboot is **not** a code
+regression in the worker. The `plytix` server is the **remote Cloudflare Worker**,
+reached through an `mcp-remote` stdio→HTTP bridge launched by `npx`. The toast is a
+transient cold-start race (npx resolving `mcp-remote@latest` against the npm registry
+before the network is fully up) and self-heals on the next launch. The worker itself
+was healthy throughout (HTTP 200, sub-second).
+
+## How `plytix` is actually wired (this is the surprising part)
+
+There are **two** transports in this repo, and the one Claude Desktop uses is the
+remote one — not the local build:
+
+| Name seen by the client | Transport | Entry point |
+|---|---|---|
+| `plytix` (Claude **Desktop** / local-agent-mode) | remote HTTP via `mcp-remote` | `~/.claude/mcp-remote-plytix.sh` → `npx -y mcp-remote https://plytix-mcp.supplyline.workers.dev/mcp` |
+| local stdio (CLI `npm start`, `npm run test:mcp`) | stdio | `node dist/index.js` (`src/index.ts`) |
+
+Key gotcha: the Desktop config lives in
+`~/Library/Application Support/Claude/claude_desktop_config.json`, **not** in
+`~/.claude.json`. That is why `claude mcp list` (the CLI) does not show `plytix`
+even though a Desktop/local-agent-mode session has the `mcp__plytix__*` tools.
+`src/worker.ts` (the Cloudflare Worker) is what serves the remote endpoint; the
+"worker auth flakiness" commits touch that path, **not** the local stdio server.
+
+## Diagnosing an attach failure
+
+1. **Is the worker up?** `curl` the endpoint — a healthy worker answers `initialize`
+   in well under a second:
+   ```bash
+   curl -s -o /dev/null -w "HTTP %{http_code} total=%{time_total}s\n" \
+     -X POST https://plytix-mcp.supplyline.workers.dev/mcp \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json, text/event-stream" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"diag","version":"0"}}}'
+   ```
+   `HTTP 200` ⇒ the remote side is fine; the failure is in the local launch chain.
+
+2. **Is the bridge launchable?** The wrapper is `npx -y mcp-remote`. `node`/`npx`
+   must be resolvable from the wrapper's `PATH` (`/usr/local/bin/node` is used, not
+   nvm). `mcp-remote` is cached under `~/.npm/_npx/`; `~/.mcp-auth/` holds its state.
+
+3. **Run the worker suite** with credentials in `.env`:
+   ```bash
+   set -a; source .env; set +a
+   node test-worker.js https://plytix-mcp.supplyline.workers.dev   # NOTE: base URL, no /mcp
+   ```
+
+## Why pinning the npx version does NOT fix the cold-start race
+
+`npx` keys its cache by the exact spec string. `npx mcp-remote@0.1.38` maps to a
+**different** cache key than the unpinned `npx mcp-remote` that populated the cache,
+so the pinned form still tries to reach the registry (verified: `npx --offline
+mcp-remote@0.1.38` reports "package not found, will be installed"). Pinning the
+version in the wrapper therefore does not remove the boot-time network dependency.
+
+The only way to take `npx` (and the network) out of the boot path is a fixed install:
+`npm install -g mcp-remote@<version>` and call the `mcp-remote` binary directly. That
+is an explicit install decision; until then, the rare reboot toast self-heals on relaunch.
+
+## Auth model (verified, intentional — not a bypass)
+
+`src/worker.ts` defines:
+
+```js
+const publicMethods = ['initialize', 'notifications/initialized', 'tools/list'];
+// ... later: reject if !allPublic && missing credentials
+```
+
+So unauthenticated `initialize`/`tools/list` correctly return **200** (a client must
+handshake and discover tools before it has anything to authenticate with), while any
+`tools/call` without credentials is rejected with
+`-32600 "Missing Plytix API credentials"`. Verified live: no PIM data leaks through the
+public URL. `test-worker.js` previously asserted `initialize` → 401, which was a stale
+assertion; it now asserts the 200 handshake **and** that an unauthenticated `tools/call`
+is rejected (the real auth boundary / regression guard).
+
+## Keeping credentials out of `argv`
+
+`mcp-remote` substitutes `${VAR}` in header **values** from `process.env`:
+
+```js
+headers[key] = value.replace(/\$\{([^}]+)}/g, (m, name) => process.env[name] ?? ...)
+```
+
+So credentials should be passed as the literal placeholders
+`--header "X-Plytix-API-Key: ${PLYTIX_API_KEY}"` (no secret in `argv` / `ps aux`), with
+the real values loaded from a `chmod 600` file into the wrapper's environment:
+
+- `~/.claude/plytix-mcp.env` (0600): `PLYTIX_API_KEY='…'`, `PLYTIX_API_PASSWORD='…'`
+  (single-quote the password — it contains `! / ; % &`).
+- `~/.claude/mcp-remote-plytix.sh`: `set -a; . "$CRED_FILE"; set +a` before `exec npx … mcp-remote "$@"`.
+- Desktop config `args`: only the URL + the literal `${…}` header placeholders.
+
+Verified end-to-end: spawning the exact config entry with a minimal env (no `PLYTIX_*`)
+still authenticates (creds resolve from the cred file), and `ps` shows only the
+`${PLYTIX_API_KEY}` placeholder, never the secret.

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,45 @@
+PROGRESS LOG — plytix-mcp
+=========================
+Session handoff notes. Newest entry on top.
+
+
+2026-06-01 — "Could not attach to MCP server plytix" investigation + hardening
+------------------------------------------------------------------------------
+Trigger: after a reboot, Claude (Desktop) showed "Could not attach to MCP server plytix".
+
+Findings:
+- `plytix` is the REMOTE Cloudflare Worker, reached via an mcp-remote stdio→HTTP
+  bridge (~/.claude/mcp-remote-plytix.sh → npx -y mcp-remote → worker /mcp). It is
+  configured in Claude Desktop's claude_desktop_config.json, NOT ~/.claude.json — which
+  is why `claude mcp list` doesn't show it but a Desktop/local-agent session has the tools.
+- Root cause of the toast: transient cold-start race — `npx mcp-remote@latest` doing a
+  registry round-trip before the network was up at reboot. Worker itself was healthy
+  (HTTP 200, <1s). Self-heals on relaunch. NOT related to the recent worker-auth commit
+  (b6062eb didn't touch the auth gate).
+- Verified BOTH transports work end-to-end: remote worker suite 10/10, local stdio
+  handshake + authed round-trip OK.
+- Security: confirmed the worker's auth model is intentional and intact — initialize/
+  tools/list are public (200), tools/call without creds is rejected (-32600). No PIM leak.
+
+Changes made:
+- REPO (PR): test-worker.js — replaced the stale "initialize must 401" assertion with
+  (a) "public handshake initialize → 200" and (b) a new "tools/call without creds must be
+  rejected" auth-boundary regression test. Suite now 10/10; unit tests 33/33.
+- REPO: docs/solutions/integration-issues/mcp-attach-failure-and-transports.md (diagnosis).
+- LOCAL (not repo): moved Plytix creds out of argv. Secrets now live in
+  ~/.claude/plytix-mcp.env (chmod 600); wrapper sources it; Desktop config passes the
+  literal ${PLYTIX_API_KEY}/${PLYTIX_API_PASSWORD} placeholders, which mcp-remote
+  substitutes from env at request time. Verified: ps shows only placeholders, never the
+  secret; the exact config entry still authenticates with a minimal env. Old config
+  backed up to claude_desktop_config.json.pre-plytix-secrets-fix.bak (chmod 600).
+
+Investigated but deliberately NOT done:
+- Pinning mcp-remote in the wrapper does NOT fix the reboot race (npx caches by exact
+  spec string; a pinned spec still hits the registry). The durable fix is
+  `npm install -g mcp-remote@<ver>` + call the binary directly — left for explicit
+  approval since it's an install.
+
+Next steps / open:
+- Decide whether to do the global mcp-remote install to fully remove the boot-time
+  network dependency.
+- The repo .env still holds real creds for local stdio testing (gitignored) — fine.

--- a/test-worker.js
+++ b/test-worker.js
@@ -127,9 +127,13 @@ async function runTests() {
     failed++;
   }
 
-  // Test 3: MCP without credentials (should fail gracefully)
+  // Test 3: Public handshake methods do NOT require credentials.
+  // An MCP client must be able to initialize and discover tools before it has
+  // anything to authenticate with, so the worker intentionally allows
+  // initialize / notifications/initialized / tools/list unauthenticated
+  // (see `publicMethods` in src/worker.ts). Only tools/call needs credentials.
   if (
-    await testEndpoint('MCP without credentials (should require auth)', async () => {
+    await testEndpoint('MCP public handshake without credentials (initialize allowed)', async () => {
       const response = await fetch(`${BASE_URL}/mcp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -140,8 +144,39 @@ async function runTests() {
         }),
       });
 
-      if (response.status !== 401) {
-        throw new Error(`Expected 401, got ${response.status}`);
+      if (response.status !== 200) {
+        throw new Error(`Expected 200 for public initialize, got ${response.status}`);
+      }
+    })
+  ) {
+    passed++;
+  } else {
+    failed++;
+  }
+
+  // Test 3b: tools/call WITHOUT credentials must be rejected. This is the actual
+  // auth boundary — a regression here would expose live PIM data through the
+  // public worker URL. Deliberately sends no X-Plytix-* headers (so it must not
+  // use fetchJson, which would attach credentials when they are present in env).
+  if (
+    await testEndpoint('MCP tools/call without credentials (must be rejected)', async () => {
+      const response = await fetch(`${BASE_URL}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'products_search', arguments: {} },
+        }),
+      });
+
+      const json = await response.json();
+      if (!json.error) {
+        throw new Error('Unauthenticated tools/call returned a result instead of an auth error');
+      }
+      if (!/credential/i.test(json.error.message || '')) {
+        throw new Error(`Expected a credentials error, got: ${json.error.message}`);
       }
     })
   ) {


### PR DESCRIPTION
## Summary

While diagnosing a *"Could not attach to MCP server plytix"* toast, I ran the worker test suite and found one failing assertion that turned out to be **stale**, not a worker bug.

`test-worker.js` asserted that an unauthenticated `initialize` must return **401**. The Cloudflare Worker intentionally treats `initialize` / `notifications/initialized` / `tools/list` as **public** handshake methods (an MCP client must handshake and discover tools before it has anything to authenticate with) and returns **200**. Only `tools/call` requires Plytix credentials.

## Changes

- **Fix the assertion**: unauthenticated `initialize` now expected to return `200` (public handshake).
- **Add an auth-boundary regression test**: assert that `tools/call` *without* credentials is rejected (`-32600 Missing Plytix API credentials`). This is the real security boundary — a regression here would expose live PIM data through the public worker URL. (Deliberately bypasses `fetchJson` so it never attaches credentials from env.)
- **Docs**: `docs/solutions/integration-issues/mcp-attach-failure-and-transports.md` documents the remote-worker-vs-local-stdio transport split, the reboot cold-start race (and why pinning the `npx mcp-remote` version does *not* fix it), the verified auth model, and the credential-out-of-`argv` pattern.
- **progress.txt**: session handoff entry.

## Verification

- `node test-worker.js https://plytix-mcp.supplyline.workers.dev` → **10/10 pass** (previously 8/9, the 9th being this stale assertion).
- `npm test` (vitest) → **33/33 pass**.
- Verified live against the deployed worker: unauthenticated `tools/call` returns the credentials error (no data); authenticated calls succeed.

## Notes

- No worker/source behavior changed — this is a test + docs PR. `git show b6062eb -- src/worker.ts` confirms the recent worker-auth commit did not touch the auth gate.
- The reboot attach toast was a transient `npx`/network cold-start; it self-heals. A durable fix (global pinned `mcp-remote` install) is noted in the docs but intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)