### PR TITLE
docs: record applied durable fix for plytix MCP attach race

### DIFF
--- a/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
+++ b/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
@@ -59,9 +59,20 @@ so the pinned form still tries to reach the registry (verified: `npx --offline
 mcp-remote@0.1.38` reports "package not found, will be installed"). Pinning the
 version in the wrapper therefore does not remove the boot-time network dependency.
 
-The only way to take `npx` (and the network) out of the boot path is a fixed install:
-`npm install -g mcp-remote@<version>` and call the `mcp-remote` binary directly. That
-is an explicit install decision; until then, the rare reboot toast self-heals on relaunch.
+The fix is to take `npx` (and the registry) out of the boot path entirely — install
+`mcp-remote` once and call the binary directly. Use a self-contained prefix so it needs
+no `sudo` and no `PATH`/nvm dependency:
+
+```bash
+npm install -g mcp-remote@0.1.38 --prefix "$HOME/.claude/mcp-tools"
+# wrapper then execs the absolute path, with an npx fallback if the install is missing:
+#   MCP_REMOTE="$HOME/.claude/mcp-tools/bin/mcp-remote"
+#   [ -x "$MCP_REMOTE" ] && exec "$MCP_REMOTE" "$@" || exec npx -y mcp-remote "$@"
+```
+
+After this, startup is just `node <local-file>` (verified ~2.3s to connect, no registry
+round-trip), so the cold-boot race no longer occurs. The remote connection itself still
+needs the network to be up, but that is the actual work, not a resolution race.
 
 ## Auth model (verified, intentional — not a bypass)
 

--- a/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
+++ b/docs/solutions/integration-issues/mcp-attach-failure-and-transports.md
@@ -60,8 +60,8 @@ mcp-remote@0.1.38` reports "package not found, will be installed"). Pinning the
 version in the wrapper therefore does not remove the boot-time network dependency.
 
 The fix is to take `npx` (and the registry) out of the boot path entirely — install
-`mcp-remote` once and call the binary directly. Use a self-contained prefix so it needs
-no `sudo` and no `PATH`/nvm dependency:
+`mcp-remote` once and call the binary directly. A self-contained prefix avoids `sudo`
+and an unstable npx cache path:
 
 ```bash
 npm install -g mcp-remote@0.1.38 --prefix "$HOME/.claude/mcp-tools"
@@ -70,9 +70,17 @@ npm install -g mcp-remote@0.1.38 --prefix "$HOME/.claude/mcp-tools"
 #   [ -x "$MCP_REMOTE" ] && exec "$MCP_REMOTE" "$@" || exec npx -y mcp-remote "$@"
 ```
 
-After this, startup is just `node <local-file>` (verified ~2.3s to connect, no registry
-round-trip), so the cold-boot race no longer occurs. The remote connection itself still
-needs the network to be up, but that is the actual work, not a resolution race.
+This removes the npm-registry round-trip (the cold-boot race). It does **not** remove
+the dependency on `node` itself: the installed `mcp-remote` bin is a Node script
+(`#!/usr/bin/env node` → `dist/proxy.js`), so `node` must be resolvable by the launched
+process. Under a Claude Desktop / macOS GUI launch the login shell and nvm are **not**
+sourced, so the wrapper's `export PATH="/usr/local/bin:/bin:/usr/bin:$PATH"` line — which
+puts a current `node` on `PATH` — is load-bearing and must stay. (`--prefix` only
+stabilizes the `mcp-remote` *binary* path; it does nothing for `node` resolution.)
+
+With both in place, startup is just `node <local-file>` (verified ~2.3s to connect, no
+registry round-trip), so the cold-boot race no longer occurs. The remote connection
+itself still needs the network to be up, but that is the actual work, not a resolution race.
 
 ## Auth model (verified, intentional — not a bypass)
 

--- a/progress.txt
+++ b/progress.txt
@@ -33,13 +33,18 @@ Changes made:
   secret; the exact config entry still authenticates with a minimal env. Old config
   backed up to claude_desktop_config.json.pre-plytix-secrets-fix.bak (chmod 600).
 
-Investigated but deliberately NOT done:
-- Pinning mcp-remote in the wrapper does NOT fix the reboot race (npx caches by exact
-  spec string; a pinned spec still hits the registry). The durable fix is
-  `npm install -g mcp-remote@<ver>` + call the binary directly — left for explicit
-  approval since it's an install.
+Durable startup fix (applied 2026-06-01, approved):
+- Pinning the npx spec does NOT help (npx caches by exact spec string; a pinned spec
+  still hits the registry). So removed npx from the boot path entirely:
+  `npm install -g mcp-remote@0.1.38 --prefix ~/.claude/mcp-tools` and pointed the
+  wrapper at the absolute binary (~/.claude/mcp-tools/bin/mcp-remote), with an npx
+  fallback if that install ever goes missing. Startup is now a local `node` exec —
+  no npm-registry round-trip — so the cold-boot race is gone. Verified: real config
+  entry connects in ~2.3s, authenticates, secret stays a placeholder in argv.
+  (mcp-remote@0.1.38: latest, published 2026-02-05, maintainers threepointone/geelen,
+  ~338k weekly downloads.)
 
 Next steps / open:
-- Decide whether to do the global mcp-remote install to fully remove the boot-time
-  network dependency.
 - The repo .env still holds real creds for local stdio testing (gitignored) — fine.
+- If ~/.claude/mcp-tools is ever wiped, the wrapper falls back to npx automatically;
+  re-run the npm install above to restore the pinned binary.


### PR DESCRIPTION
Follow-up to #20 (docs only).

#20 documented the *"Could not attach to MCP server plytix"* diagnosis. This updates the same note + `progress.txt` to record that the npx cold-start race was actually **resolved**: `mcp-remote@0.1.38` is now installed into a self-contained prefix (`~/.claude/mcp-tools`) and the bridge wrapper execs the absolute binary (with an `npx` fallback), so startup is a local `node` exec with no npm-registry round-trip.

No code changes — 2 files (`docs/solutions/integration-issues/mcp-attach-failure-and-transports.md`, `progress.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)