### PR TITLE
feat(worker): OAuth 2.0 for MCP clients (hardened)

### DIFF
--- a/src/__tests__/worker-oauth.test.ts
+++ b/src/__tests__/worker-oauth.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import worker from '../worker.js';
+
+// ─────────────────────────────────────────────────────────────
+// Test harness: in-memory KV + helpers
+// ─────────────────────────────────────────────────────────────
+
+interface PutCall {
+  key: string;
+  value: string;
+  opts?: { expirationTtl?: number };
+}
+
+function makeKV() {
+  const store = new Map<string, string>();
+  const putCalls: PutCall[] = [];
+  return {
+    store,
+    putCalls,
+    async get(key: string, type?: 'json' | 'text') {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+      store.set(key, value);
+      putCalls.push({ key, value, opts });
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  };
+}
+
+const SECRET = 'unit-test-oauth-secret-0123456789abcdef';
+const ORIGIN = 'https://mcp.example.com';
+const REGISTERED_REDIRECT = 'https://claude.ai/api/mcp/auth_callback';
+const ATTACKER_REDIRECT = 'https://attacker.example.com/callback';
+const API_KEY = 'PLYTIX_KEY_DISTINCTIVE_VALUE';
+const API_PASSWORD = 'PLYTIX_PASS_DISTINCTIVE_VALUE';
+
+function makeEnv(kv: ReturnType<typeof makeKV>, overrides: Record<string, unknown> = {}) {
+  return {
+    PLYTIX_API_BASE: 'https://pim.example.com',
+    PLYTIX_AUTH_URL: 'https://auth.example.com/get-token',
+    OAUTH_KV: kv,
+    OAUTH_TOKEN_SECRET: SECRET,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function call(env: any, path: string, init?: RequestInit) {
+  return worker.fetch(new Request(`${ORIGIN}${path}`, init), env);
+}
+
+function form(fields: Record<string, string>): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(fields).toString(),
+  };
+}
+
+// Mirror the worker's S256 derivation so happy-path verifiers match.
+function base64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+async function s256(verifier: string): Promise<string> {
+  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64url(new Uint8Array(hash));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function registerClient(env: any, redirectUris: string[]): Promise<string> {
+  const res = await call(env, '/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ redirect_uris: redirectUris, client_name: 'test-client' }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { client_id: string };
+  return body.client_id;
+}
+
+// Stub Plytix credential validation (and any downstream Plytix call) as success.
+function stubPlytixOk() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [{ access_token: 'plytix-tok', expires_in: 900 }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─────────────────────────────────────────────────────────────
+// redirect_uri allowlist (the HIGH finding)
+// ─────────────────────────────────────────────────────────────
+
+describe('OAuth redirect_uri allowlist', () => {
+  it('GET /authorize rejects an unregistered redirect_uri before rendering the form', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+
+    const challenge = await s256('verifier-abc');
+    const res = await call(
+      env,
+      `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+        ATTACKER_REDIRECT
+      )}&code_challenge=${challenge}&code_challenge_method=S256`
+    );
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).not.toContain('<form'); // never shows the credential form
+    expect(JSON.parse(text).error).toBe('invalid_request');
+  });
+
+  it('GET /authorize renders the form for a registered redirect_uri', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+
+    const challenge = await s256('verifier-abc');
+    const res = await call(
+      env,
+      `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+        REGISTERED_REDIRECT
+      )}&code_challenge=${challenge}&code_challenge_method=S256`
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    expect(await res.text()).toContain('<form');
+  });
+
+  it('POST /authorize rejects an unregistered redirect_uri WITHOUT redirecting to it', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const challenge = await s256('verifier-abc');
+
+    const res = await call(
+      env,
+      '/authorize',
+      form({
+        client_id: clientId,
+        redirect_uri: ATTACKER_REDIRECT,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        api_key: API_KEY,
+        api_password: API_PASSWORD,
+      })
+    );
+
+    expect(res.status).toBe(400); // not a 302
+    expect(res.headers.get('Location')).toBeNull();
+    expect((await res.json()).error).toBe('invalid_request');
+    // No code minted for the attacker.
+    expect([...kv.store.keys()].some((k) => k.startsWith('code:'))).toBe(false);
+  });
+
+  it('POST /authorize rejects an unknown client_id', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const challenge = await s256('verifier-abc');
+
+    const res = await call(
+      env,
+      '/authorize',
+      form({
+        client_id: 'never-registered',
+        redirect_uri: REGISTERED_REDIRECT,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        api_key: API_KEY,
+        api_password: API_PASSWORD,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('Location')).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// S256 enforcement
+// ─────────────────────────────────────────────────────────────
+
+describe('OAuth PKCE S256 enforcement', () => {
+  it('GET /authorize rejects a non-S256 code_challenge_method', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+
+    const res = await call(
+      env,
+      `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+        REGISTERED_REDIRECT
+      )}&code_challenge=plainchallenge&code_challenge_method=plain`
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid_request');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Full flow: encryption at rest, token TTL, PKCE verification
+// ─────────────────────────────────────────────────────────────
+
+describe('OAuth authorization-code flow (encryption + TTL + PKCE)', () => {
+  async function authorizeAndGetCode(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    env: any,
+    clientId: string,
+    challenge: string
+  ): Promise<string> {
+    const res = await call(
+      env,
+      '/authorize',
+      form({
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: 'xyz',
+        api_key: API_KEY,
+        api_password: API_PASSWORD,
+      })
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get('Location');
+    expect(location).toBeTruthy();
+    const url = new URL(location as string);
+    expect(url.searchParams.get('state')).toBe('xyz');
+    return url.searchParams.get('code') as string;
+  }
+
+  it('stores credentials encrypted (no plaintext) in the auth code and token records', async () => {
+    stubPlytixOk();
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const verifier = 'verifier-1234567890-abcdefghijklmnop';
+    const challenge = await s256(verifier);
+
+    const code = await authorizeAndGetCode(env, clientId, challenge);
+
+    // Auth code record: encrypted blob present, no plaintext credentials.
+    const codeRecord = kv.store.get(`code:${code}`) as string;
+    expect(codeRecord).toContain('enc_creds');
+    expect(codeRecord).not.toContain(API_KEY);
+    expect(codeRecord).not.toContain(API_PASSWORD);
+
+    // Exchange the code.
+    const tokenRes = await call(
+      env,
+      '/token',
+      form({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+      })
+    );
+    expect(tokenRes.status).toBe(200);
+    const tokenBody = (await tokenRes.json()) as {
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+    };
+    expect(tokenBody.token_type).toBe('bearer');
+    expect(tokenBody.expires_in).toBe(60 * 60 * 24 * 30);
+
+    // Token record: encrypted blob, no plaintext, and a bounded TTL.
+    const tokenRecord = kv.store.get(`token:${tokenBody.access_token}`) as string;
+    expect(tokenRecord).toContain('enc_creds');
+    expect(tokenRecord).not.toContain(API_KEY);
+    expect(tokenRecord).not.toContain(API_PASSWORD);
+    const tokenPut = kv.putCalls.find((c) => c.key === `token:${tokenBody.access_token}`);
+    expect(tokenPut?.opts?.expirationTtl).toBe(60 * 60 * 24 * 30);
+
+    // Code is one-time use (deleted on redemption).
+    expect(kv.store.has(`code:${code}`)).toBe(false);
+  });
+
+  it('rejects token exchange when the PKCE verifier is wrong', async () => {
+    stubPlytixOk();
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const challenge = await s256('the-real-verifier');
+    const code = await authorizeAndGetCode(env, clientId, challenge);
+
+    const tokenRes = await call(
+      env,
+      '/token',
+      form({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: 'WRONG-verifier',
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+      })
+    );
+
+    expect(tokenRes.status).toBe(400);
+    expect((await tokenRes.json()).error).toBe('invalid_grant');
+  });
+
+  it('rejects token exchange when redirect_uri does not match the code', async () => {
+    stubPlytixOk();
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const verifier = 'verifier-aaa';
+    const challenge = await s256(verifier);
+    const code = await authorizeAndGetCode(env, clientId, challenge);
+
+    const tokenRes = await call(
+      env,
+      '/token',
+      form({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        client_id: clientId,
+        redirect_uri: ATTACKER_REDIRECT,
+      })
+    );
+
+    expect(tokenRes.status).toBe(400);
+    expect((await tokenRes.json()).error).toBe('invalid_grant');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// MCP auth gate via OAuth bearer token
+// ─────────────────────────────────────────────────────────────
+
+describe('MCP auth gate with OAuth tokens', () => {
+  async function mintToken(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    env: any
+  ): Promise<string> {
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const verifier = 'verifier-mcp-test';
+    const challenge = await s256(verifier);
+    const authRes = await call(
+      env,
+      '/authorize',
+      form({
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        api_key: API_KEY,
+        api_password: API_PASSWORD,
+      })
+    );
+    const code = new URL(authRes.headers.get('Location') as string).searchParams.get('code') as string;
+    const tokenRes = await call(
+      env,
+      '/token',
+      form({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+      })
+    );
+    return ((await tokenRes.json()) as { access_token: string }).access_token;
+  }
+
+  it('rejects an unknown OAuth bearer token on a non-public method', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+
+    const res = await call(env, '/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer not-a-real-token' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'products_get', params: {} }),
+    });
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error.code).toBe(-32600);
+  });
+
+  it('accepts a valid OAuth bearer token (resolves encrypted creds, passes the auth gate)', async () => {
+    stubPlytixOk();
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const token = await mintToken(env);
+
+    const res = await call(env, '/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping', params: {} }),
+    });
+
+    // The decrypted credentials let the request past the auth gate, so it must
+    // NOT be the -32600 "Authentication required" 401.
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,6 +22,7 @@ import { validateAttributeValue } from './utils/validate-attribute.js';
 interface Env {
   PLYTIX_API_BASE?: string;
   PLYTIX_AUTH_URL?: string;
+  OAUTH_KV?: KVNamespace;
 }
 
 interface JsonRpcRequest {
@@ -116,6 +117,95 @@ function getCorsHeaders(request: Request): Record<string, string> {
   // This will cause browsers to block cross-origin requests from unauthorized sites
 
   return headers;
+}
+
+// ─────────────────────────────────────────────────────────────
+// OAuth Helpers
+// ─────────────────────────────────────────────────────────────
+
+function generateToken(bytes = 32): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function computeS256(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderAuthorizePage(params: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string;
+  error?: string;
+}): string {
+  const errorHtml = params.error
+    ? `<div class="error">${escapeHtml(params.error)}</div>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize - Plytix MCP</title>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:#f5f5f5;padding:20px;display:flex;justify-content:center;align-items:center;min-height:100vh}
+    .card{background:#fff;border-radius:12px;box-shadow:0 2px 10px rgba(0,0,0,.1);padding:40px;max-width:420px;width:100%}
+    h1{font-size:24px;color:#1a1a1a;margin-bottom:8px}
+    .subtitle{color:#666;font-size:14px;line-height:1.5;margin-bottom:24px}
+    .info{background:#f0f4ff;border-radius:8px;padding:12px 16px;margin-bottom:24px;font-size:13px;color:#4f46e5;line-height:1.5}
+    .error{background:#fef2f2;border:1px solid #fecaca;border-radius:8px;padding:12px 16px;margin-bottom:24px;font-size:13px;color:#dc2626;line-height:1.5}
+    label{display:block;font-size:14px;font-weight:500;color:#333;margin-bottom:6px}
+    input[type="text"],input[type="password"]{width:100%;padding:10px 12px;border:1px solid #ddd;border-radius:8px;font-size:14px;margin-bottom:16px}
+    input:focus{outline:none;border-color:#4f46e5;box-shadow:0 0 0 3px rgba(79,70,229,.1)}
+    button{width:100%;padding:12px;background:#4f46e5;color:#fff;border:none;border-radius:8px;font-size:16px;font-weight:500;cursor:pointer}
+    button:hover{background:#4338ca}
+    .help{margin-top:16px;font-size:12px;color:#999;text-align:center}
+    .help a{color:#4f46e5;text-decoration:none}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Plytix MCP</h1>
+    <p class="subtitle">An application is requesting access to your Plytix PIM data.</p>
+    ${errorHtml}
+    <div class="info">Enter your Plytix API credentials. They are stored securely and used only to access the Plytix API on your behalf.</div>
+    <form method="POST" action="/authorize">
+      <input type="hidden" name="client_id" value="${escapeHtml(params.clientId)}">
+      <input type="hidden" name="redirect_uri" value="${escapeHtml(params.redirectUri)}">
+      <input type="hidden" name="state" value="${escapeHtml(params.state)}">
+      <input type="hidden" name="code_challenge" value="${escapeHtml(params.codeChallenge)}">
+      <input type="hidden" name="code_challenge_method" value="${escapeHtml(params.codeChallengeMethod)}">
+      <input type="hidden" name="scope" value="${escapeHtml(params.scope)}">
+      <label for="api_key">API Key</label>
+      <input type="text" id="api_key" name="api_key" required placeholder="Your Plytix API key" autocomplete="username">
+      <label for="api_password">API Password</label>
+      <input type="password" id="api_password" name="api_password" required placeholder="Your Plytix API password" autocomplete="current-password">
+      <button type="submit">Authorize</button>
+    </form>
+    <p class="help">Find your API credentials in <a href="https://pim.plytix.com/settings/api" target="_blank" rel="noopener">Plytix Settings</a></p>
+  </div>
+</body>
+</html>`;
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -2273,6 +2363,288 @@ export default {
       });
     }
 
+    // ── OAuth Discovery ──────────────────────────────────────────
+
+    // Protected Resource Metadata (RFC 9728)
+    if (url.pathname === '/.well-known/oauth-protected-resource') {
+      return new Response(
+        JSON.stringify({
+          resource: url.origin,
+          authorization_servers: [url.origin],
+          bearer_methods_supported: ['header'],
+        }),
+        { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+      );
+    }
+
+    // Authorization Server Metadata (RFC 8414)
+    if (url.pathname === '/.well-known/oauth-authorization-server') {
+      return new Response(
+        JSON.stringify({
+          issuer: url.origin,
+          authorization_endpoint: `${url.origin}/authorize`,
+          token_endpoint: `${url.origin}/token`,
+          registration_endpoint: `${url.origin}/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code'],
+          code_challenge_methods_supported: ['S256'],
+          token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
+          scopes_supported: ['plytix'],
+        }),
+        { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+      );
+    }
+
+    // ── Dynamic Client Registration (RFC 7591) ──────────────────
+
+    if (url.pathname === '/register' && request.method === 'POST') {
+      if (!env.OAUTH_KV) {
+        return new Response(
+          JSON.stringify({ error: 'server_error', error_description: 'OAuth storage not configured' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      try {
+        const regBody = (await request.json()) as Record<string, unknown>;
+        const clientId = generateToken(16);
+        const authMethod = (regBody.token_endpoint_auth_method as string) || 'none';
+        const clientSecret = authMethod === 'none' ? undefined : generateToken(32);
+
+        const registration = {
+          client_id: clientId,
+          ...(clientSecret ? { client_secret: clientSecret } : {}),
+          redirect_uris: regBody.redirect_uris || [],
+          client_name: regBody.client_name || '',
+          token_endpoint_auth_method: authMethod,
+          grant_types: ['authorization_code'],
+          response_types: ['code'],
+        };
+
+        await env.OAUTH_KV.put(`client:${clientId}`, JSON.stringify(registration));
+
+        return new Response(JSON.stringify(registration), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
+      } catch {
+        return new Response(
+          JSON.stringify({ error: 'invalid_client_metadata' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+    }
+
+    // ── Authorization Endpoint ───────────────────────────────────
+
+    if (url.pathname === '/authorize' && request.method === 'GET') {
+      const clientId = url.searchParams.get('client_id') || '';
+      const redirectUri = url.searchParams.get('redirect_uri') || '';
+      const state = url.searchParams.get('state') || '';
+      const codeChallenge = url.searchParams.get('code_challenge') || '';
+      const codeChallengeMethod = url.searchParams.get('code_challenge_method') || '';
+      const scope = url.searchParams.get('scope') || '';
+      const responseType = url.searchParams.get('response_type') || '';
+
+      if (responseType !== 'code') {
+        return new Response(
+          JSON.stringify({ error: 'unsupported_response_type' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (!clientId || !redirectUri || !codeChallenge) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'Missing required parameters: client_id, redirect_uri, code_challenge' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      return new Response(
+        renderAuthorizePage({ clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope }),
+        { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+      );
+    }
+
+    if (url.pathname === '/authorize' && request.method === 'POST') {
+      if (!env.OAUTH_KV) {
+        return new Response(
+          JSON.stringify({ error: 'server_error', error_description: 'OAuth storage not configured' }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const formData = await request.formData();
+      const clientId = (formData.get('client_id') as string) || '';
+      const redirectUri = (formData.get('redirect_uri') as string) || '';
+      const state = (formData.get('state') as string) || '';
+      const codeChallenge = (formData.get('code_challenge') as string) || '';
+      const codeChallengeMethod = (formData.get('code_challenge_method') as string) || '';
+      const scope = (formData.get('scope') as string) || '';
+      const apiKey = (formData.get('api_key') as string) || '';
+      const apiPassword = (formData.get('api_password') as string) || '';
+
+      if (!apiKey || !apiPassword) {
+        return new Response(
+          renderAuthorizePage({
+            clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope,
+            error: 'Please enter both API key and password.',
+          }),
+          { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+        );
+      }
+
+      // Validate credentials against Plytix
+      try {
+        const authUrl = env.PLYTIX_AUTH_URL || 'https://auth.plytix.com/auth/api/get-token';
+        const authResponse = await fetch(authUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ api_key: apiKey, api_password: apiPassword }),
+        });
+
+        if (!authResponse.ok) {
+          return new Response(
+            renderAuthorizePage({
+              clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope,
+              error: 'Invalid Plytix credentials. Please check your API key and password.',
+            }),
+            { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+          );
+        }
+      } catch {
+        return new Response(
+          renderAuthorizePage({
+            clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope,
+            error: 'Could not verify credentials. Please try again.',
+          }),
+          { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+        );
+      }
+
+      // Generate auth code and store with credentials
+      const code = generateToken(32);
+      await env.OAUTH_KV.put(
+        `code:${code}`,
+        JSON.stringify({
+          client_id: clientId,
+          redirect_uri: redirectUri,
+          code_challenge: codeChallenge,
+          code_challenge_method: codeChallengeMethod,
+          api_key: apiKey,
+          api_password: apiPassword,
+        }),
+        { expirationTtl: 600 } // 10 minute TTL for auth codes
+      );
+
+      // Redirect back to client with auth code
+      const redirect = new URL(redirectUri);
+      redirect.searchParams.set('code', code);
+      if (state) redirect.searchParams.set('state', state);
+
+      return Response.redirect(redirect.toString(), 302);
+    }
+
+    // ── Token Endpoint ───────────────────────────────────────────
+
+    if (url.pathname === '/token' && request.method === 'POST') {
+      if (!env.OAUTH_KV) {
+        return new Response(
+          JSON.stringify({ error: 'server_error', error_description: 'OAuth storage not configured' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      // Parse body (supports both form-encoded and JSON)
+      let tokenParams: Record<string, string>;
+      const contentType = request.headers.get('Content-Type') || '';
+      if (contentType.includes('application/json')) {
+        tokenParams = (await request.json()) as Record<string, string>;
+      } else {
+        const formData = await request.formData();
+        tokenParams = {
+          grant_type: (formData.get('grant_type') as string) || '',
+          code: (formData.get('code') as string) || '',
+          code_verifier: (formData.get('code_verifier') as string) || '',
+          client_id: (formData.get('client_id') as string) || '',
+          redirect_uri: (formData.get('redirect_uri') as string) || '',
+        };
+      }
+
+      if (tokenParams.grant_type !== 'authorization_code') {
+        return new Response(
+          JSON.stringify({ error: 'unsupported_grant_type' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      const { code, code_verifier, client_id: tokenClientId, redirect_uri: tokenRedirectUri } = tokenParams;
+
+      if (!code || !code_verifier) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'Missing code or code_verifier' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      // Look up auth code
+      const codeData = (await env.OAUTH_KV.get(`code:${code}`, 'json')) as {
+        client_id: string;
+        redirect_uri: string;
+        code_challenge: string;
+        code_challenge_method: string;
+        api_key: string;
+        api_password: string;
+      } | null;
+
+      if (!codeData) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_grant', error_description: 'Invalid or expired authorization code' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      // Delete the code immediately (one-time use)
+      await env.OAUTH_KV.delete(`code:${code}`);
+
+      // Validate client_id and redirect_uri match
+      if (codeData.client_id !== tokenClientId || codeData.redirect_uri !== tokenRedirectUri) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_grant', error_description: 'Client ID or redirect URI mismatch' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      // Verify PKCE (S256)
+      const expectedChallenge = await computeS256(code_verifier);
+      if (expectedChallenge !== codeData.code_challenge) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_grant', error_description: 'PKCE verification failed' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+        );
+      }
+
+      // Generate access token and store with credentials (no expiration)
+      const accessToken = generateToken(32);
+      await env.OAUTH_KV.put(
+        `token:${accessToken}`,
+        JSON.stringify({
+          api_key: codeData.api_key,
+          api_password: codeData.api_password,
+          client_id: codeData.client_id,
+          created_at: new Date().toISOString(),
+        })
+      );
+
+      return new Response(
+        JSON.stringify({
+          access_token: accessToken,
+          token_type: 'bearer',
+        }),
+        { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+      );
+    }
+
     // Server info
     if (url.pathname === '/' && request.method === 'GET') {
       return new Response(
@@ -2286,6 +2658,16 @@ export default {
           },
           authentication: {
             methods: [
+              {
+                type: 'oauth',
+                endpoints: {
+                  metadata: '/.well-known/oauth-authorization-server',
+                  authorize: '/authorize',
+                  token: '/token',
+                  register: '/register',
+                },
+                note: 'For Claude web and other OAuth-capable MCP clients',
+              },
               {
                 type: 'headers',
                 required: ['X-Plytix-API-Key', 'X-Plytix-API-Password'],
@@ -2357,21 +2739,34 @@ export default {
       );
 
       // Extract API credentials from headers
-      // Supports two formats:
+      // Supports three formats:
       // 1. Custom headers: X-Plytix-API-Key and X-Plytix-API-Password
-      // 2. Bearer token: Authorization: Bearer <api_key>:<api_password>
+      // 2. Bearer token (BYOK): Authorization: Bearer <api_key>:<api_password>
+      // 3. Bearer token (OAuth): Authorization: Bearer <oauth_access_token>
       let apiKey = request.headers.get('X-Plytix-API-Key');
       let apiPassword = request.headers.get('X-Plytix-API-Password');
 
-      // Fallback to Bearer token for clients that only support an Authorization header
+      // Fallback to the Authorization header for clients that can't send custom headers.
+      // Bearer <key>:<password> = BYOK; Bearer <opaque> = OAuth access token (resolved via KV).
       if (!apiKey || !apiPassword) {
         const authHeader = request.headers.get('Authorization');
         if (authHeader?.startsWith('Bearer ')) {
-          const token = authHeader.slice(7); // Remove 'Bearer ' prefix
+          const token = authHeader.slice(7);
           const colonIndex = token.indexOf(':');
           if (colonIndex > 0) {
+            // BYOK format: key:password
             apiKey = token.slice(0, colonIndex);
             apiPassword = token.slice(colonIndex + 1);
+          } else if (env.OAUTH_KV) {
+            // OAuth token — look up credentials in KV
+            const tokenData = (await env.OAUTH_KV.get(`token:${token}`, 'json')) as {
+              api_key: string;
+              api_password: string;
+            } | null;
+            if (tokenData) {
+              apiKey = tokenData.api_key;
+              apiPassword = tokenData.api_password;
+            }
           }
         }
       }
@@ -2385,12 +2780,16 @@ export default {
             error: {
               code: -32600,
               message:
-                'Missing Plytix API credentials. Provide either X-Plytix-API-Key and X-Plytix-API-Password headers, or Authorization: Bearer <api_key>:<api_password>',
+                'Authentication required. Use OAuth, provide X-Plytix-API-Key/X-Plytix-API-Password headers, or Authorization: Bearer <api_key>:<api_password>',
             },
           }),
           {
             status: 401,
-            headers: { 'Content-Type': 'application/json', ...corsHeaders },
+            headers: {
+              'Content-Type': 'application/json',
+              'WWW-Authenticate': `Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource"`,
+              ...corsHeaders,
+            },
           }
         );
       }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -23,6 +23,12 @@ interface Env {
   PLYTIX_API_BASE?: string;
   PLYTIX_AUTH_URL?: string;
   OAUTH_KV?: KVNamespace;
+  // Secret used to derive the AES-GCM key that encrypts stored Plytix
+  // credentials at rest in OAUTH_KV. Set via `wrangler secret put
+  // OAUTH_TOKEN_SECRET`. When OAUTH_KV is configured, the OAuth endpoints
+  // refuse to operate without this secret so credentials are never stored
+  // in plaintext.
+  OAUTH_TOKEN_SECRET?: string;
 }
 
 interface JsonRpcRequest {
@@ -132,10 +138,80 @@ function generateToken(bytes = 32): string {
 async function computeS256(verifier: string): Promise<string> {
   const data = new TextEncoder().encode(verifier);
   const hash = await crypto.subtle.digest('SHA-256', data);
-  return btoa(String.fromCharCode(...new Uint8Array(hash)))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  return base64urlEncode(new Uint8Array(hash));
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlDecode(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// Derive a stable AES-GCM key from the configured secret. The secret is
+// stretched through SHA-256 to a fixed 256-bit key.
+async function deriveCredKey(secret: string): Promise<CryptoKey> {
+  const material = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+  return crypto.subtle.importKey('raw', material, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+}
+
+// Encrypt the Plytix credential pair for storage in KV. Output is
+// base64url(iv[12] || ciphertext+tag). A fresh random IV is used per call.
+async function encryptCreds(
+  creds: { api_key: string; api_password: string },
+  secret: string
+): Promise<string> {
+  const key = await deriveCredKey(secret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(creds));
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+  );
+  const combined = new Uint8Array(iv.length + ciphertext.length);
+  combined.set(iv, 0);
+  combined.set(ciphertext, iv.length);
+  return base64urlEncode(combined);
+}
+
+// Decrypt a credential blob produced by encryptCreds. Throws if the secret
+// is wrong or the blob is tampered (AES-GCM authentication failure).
+async function decryptCreds(
+  blob: string,
+  secret: string
+): Promise<{ api_key: string; api_password: string }> {
+  const key = await deriveCredKey(secret);
+  const combined = base64urlDecode(blob);
+  const iv = combined.slice(0, 12);
+  const ciphertext = combined.slice(12);
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+// Validate that a request's redirect_uri exactly matches one the client
+// registered via Dynamic Client Registration. Returns true only when the
+// client exists and the redirect_uri is an exact-string member of its
+// registered list. This is the control that prevents authorization codes
+// (and the credentials they unlock) from being delivered to an
+// attacker-controlled URL.
+async function isRegisteredRedirectUri(
+  kv: KVNamespace,
+  clientId: string,
+  redirectUri: string
+): Promise<boolean> {
+  if (!clientId || !redirectUri) return false;
+  const client = (await kv.get(`client:${clientId}`, 'json')) as {
+    redirect_uris?: unknown;
+  } | null;
+  if (!client || !Array.isArray(client.redirect_uris)) return false;
+  return client.redirect_uris.includes(redirectUri);
 }
 
 function escapeHtml(str: string): string {
@@ -2438,6 +2514,13 @@ export default {
     // ── Authorization Endpoint ───────────────────────────────────
 
     if (url.pathname === '/authorize' && request.method === 'GET') {
+      if (!env.OAUTH_KV) {
+        return new Response(
+          JSON.stringify({ error: 'server_error', error_description: 'OAuth storage not configured' }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
       const clientId = url.searchParams.get('client_id') || '';
       const redirectUri = url.searchParams.get('redirect_uri') || '';
       const state = url.searchParams.get('state') || '';
@@ -2460,6 +2543,27 @@ export default {
         );
       }
 
+      // Only S256 PKCE is supported (and advertised in metadata). Reject any
+      // other method up front rather than silently treating it as S256.
+      if (codeChallengeMethod !== 'S256') {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'code_challenge_method must be S256' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Reject before rendering the credential form unless the redirect_uri is
+      // registered to this client. Without this the worker's own login page
+      // becomes a credential-harvesting oracle: an attacker who initiates the
+      // flow with their own redirect_uri + PKCE challenge would receive an auth
+      // code (and thus the victim's credentials) at a URL they control.
+      if (!(await isRegisteredRedirectUri(env.OAUTH_KV, clientId, redirectUri))) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'redirect_uri is not registered for this client' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
       return new Response(
         renderAuthorizePage({ clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope }),
         { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
@@ -2467,9 +2571,17 @@ export default {
     }
 
     if (url.pathname === '/authorize' && request.method === 'POST') {
-      if (!env.OAUTH_KV) {
+      const oauthKv = env.OAUTH_KV;
+      if (!oauthKv) {
         return new Response(
           JSON.stringify({ error: 'server_error', error_description: 'OAuth storage not configured' }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      const tokenSecret = env.OAUTH_TOKEN_SECRET;
+      if (!tokenSecret) {
+        return new Response(
+          JSON.stringify({ error: 'server_error', error_description: 'OAuth credential encryption not configured' }),
           { status: 500, headers: { 'Content-Type': 'application/json' } }
         );
       }
@@ -2483,6 +2595,24 @@ export default {
       const scope = (formData.get('scope') as string) || '';
       const apiKey = (formData.get('api_key') as string) || '';
       const apiPassword = (formData.get('api_password') as string) || '';
+
+      // Re-validate the redirect_uri against the registered client — never
+      // trust the hidden form field. On failure return an error directly; do
+      // NOT redirect to the supplied URL (that redirect is the exfil sink).
+      if (!(await isRegisteredRedirectUri(oauthKv, clientId, redirectUri))) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'redirect_uri is not registered for this client' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Enforce S256 PKCE (matches advertised metadata).
+      if (codeChallengeMethod !== 'S256' || !codeChallenge) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_request', error_description: 'code_challenge with method S256 is required' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
 
       if (!apiKey || !apiPassword) {
         return new Response(
@@ -2522,22 +2652,22 @@ export default {
         );
       }
 
-      // Generate auth code and store with credentials
+      // Generate auth code and store with ENCRYPTED credentials (10-min TTL).
       const code = generateToken(32);
-      await env.OAUTH_KV.put(
+      const encCreds = await encryptCreds({ api_key: apiKey, api_password: apiPassword }, tokenSecret);
+      await oauthKv.put(
         `code:${code}`,
         JSON.stringify({
           client_id: clientId,
           redirect_uri: redirectUri,
           code_challenge: codeChallenge,
           code_challenge_method: codeChallengeMethod,
-          api_key: apiKey,
-          api_password: apiPassword,
+          enc_creds: encCreds,
         }),
         { expirationTtl: 600 } // 10 minute TTL for auth codes
       );
 
-      // Redirect back to client with auth code
+      // Redirect back to the (validated) client with the auth code.
       const redirect = new URL(redirectUri);
       redirect.searchParams.set('code', code);
       if (state) redirect.searchParams.set('state', state);
@@ -2592,9 +2722,7 @@ export default {
         client_id: string;
         redirect_uri: string;
         code_challenge: string;
-        code_challenge_method: string;
-        api_key: string;
-        api_password: string;
+        enc_creds: string;
       } | null;
 
       if (!codeData) {
@@ -2624,22 +2752,26 @@ export default {
         );
       }
 
-      // Generate access token and store with credentials (no expiration)
+      // Generate access token. Carry the already-encrypted credential blob
+      // from the auth code straight into the token record (same key, so no
+      // decrypt/re-encrypt needed) and bound the token's lifetime.
       const accessToken = generateToken(32);
+      const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
       await env.OAUTH_KV.put(
         `token:${accessToken}`,
         JSON.stringify({
-          api_key: codeData.api_key,
-          api_password: codeData.api_password,
+          enc_creds: codeData.enc_creds,
           client_id: codeData.client_id,
           created_at: new Date().toISOString(),
-        })
+        }),
+        { expirationTtl: TOKEN_TTL_SECONDS }
       );
 
       return new Response(
         JSON.stringify({
           access_token: accessToken,
           token_type: 'bearer',
+          expires_in: TOKEN_TTL_SECONDS,
         }),
         { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
       );
@@ -2757,15 +2889,20 @@ export default {
             // BYOK format: key:password
             apiKey = token.slice(0, colonIndex);
             apiPassword = token.slice(colonIndex + 1);
-          } else if (env.OAUTH_KV) {
-            // OAuth token — look up credentials in KV
+          } else if (env.OAUTH_KV && env.OAUTH_TOKEN_SECRET) {
+            // OAuth token — resolve the encrypted credential blob from KV.
             const tokenData = (await env.OAUTH_KV.get(`token:${token}`, 'json')) as {
-              api_key: string;
-              api_password: string;
+              enc_creds?: string;
             } | null;
-            if (tokenData) {
-              apiKey = tokenData.api_key;
-              apiPassword = tokenData.api_password;
+            if (tokenData?.enc_creds) {
+              try {
+                const creds = await decryptCreds(tokenData.enc_creds, env.OAUTH_TOKEN_SECRET);
+                apiKey = creds.api_key;
+                apiPassword = creds.api_password;
+              } catch {
+                // Tampered or undecryptable blob — leave credentials unset so
+                // the request falls through to the 401 below.
+              }
             }
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
     "node_modules",
     "dist",
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "src/worker.ts",
+    "src/worker-client.ts",
+    "src/worker-lookup.ts"
   ]
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,6 +30,13 @@ command = "npm run build:worker"
 binding = "OAUTH_KV"
 id = "REPLACE_WITH_KV_NAMESPACE_ID"
 
+# OAuth requires a secret used to encrypt stored Plytix credentials at rest.
+# It is NOT declared here (secrets never live in wrangler.toml). Set it with:
+#   wrangler secret put OAUTH_TOKEN_SECRET
+# Use a long random value (e.g. `openssl rand -hex 32`). When OAUTH_KV is
+# configured but this secret is unset, the OAuth /authorize endpoint refuses
+# to issue codes so credentials are never persisted in plaintext.
+
 # Observability
 [observability]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,6 +23,13 @@ port = 8787
 [build]
 command = "npm run build:worker"
 
+# KV namespace for OAuth token storage
+# Create with: wrangler kv namespace create OAUTH_KV
+# Then paste the ID below
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
 # Observability
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

Adds OAuth 2.0 (authorization-code + PKCE) to the Cloudflare Worker so OAuth-capable MCP clients — **Claude web, desktop, and mobile connectors** — can authenticate. The connector UI only accepts a URL + OAuth; it has no field for our `X-Plytix-*` headers, so OAuth is the only way to connect the Worker from the Claude apps. BYOK header auth is unchanged and still works for programmatic clients.

The Worker acts as its own authorization server: the user's Plytix API key+password remain the real secret, and OAuth wraps them. Endpoints added: `/.well-known/oauth-protected-resource` (RFC 9728), `/.well-known/oauth-authorization-server` (RFC 8414), `/register` (RFC 7591 DCR), `/authorize`, `/token`.

## Credit

Original implementation by **@pavlotsyhanok** (`b88521d`), cherry-picked from the `arc-co/plytix-mcp` fork with authorship preserved. Thank you! 🙏 The remaining commits harden it for landing.

## Security review

Ran a multi-agent security review (identify → parallel false-positive filters → keep ≥8/10 confidence). One real issue, three dismissed:

- **HIGH (9/10) — auth-code / credential exfiltration via missing `redirect_uri` validation.** The registered client record was written but never read, so an attacker who initiated the flow with their own `redirect_uri` + PKCE challenge could have a victim's auth code (and thus Plytix credentials) delivered to a URL they control. PKCE provides no protection here (the attacker holds the verifier). **Fixed.**
- Dismissed: PKCE-method-not-enforced (pinned to S256 — stricter, not weaker), non-expiring tokens (storage/hardening), open DCR (standard RFC 7591 behavior Claude requires).

## Hardening in this PR

1. **`redirect_uri` allowlist** — `GET`/`POST /authorize` load `client:<id>` and require an exact-match registered `redirect_uri` before rendering the form or processing credentials; on failure they error out and **never redirect** to the supplied URL.
2. **S256 enforcement** — non-S256 `code_challenge_method` is rejected (matches advertised metadata).
3. **Credential encryption at rest** — Plytix credentials are AES-GCM encrypted (key derived from a required `OAUTH_TOKEN_SECRET`) before being stored in KV, carried code→token, and decrypted only at request time. If the secret is unset, `/authorize` refuses to mint codes so credentials are never persisted in plaintext.
4. **Token lifecycle** — access tokens carry a 30-day TTL; `/token` returns `expires_in`.
5. **Build fix** — excluded the Worker entry files from the Node `tsconfig.json` (they're checked by `tsconfig.worker.json`) so the new `KVNamespace` type resolves.

## Deploy steps (required before OAuth works)

```bash
wrangler kv namespace create OAUTH_KV    # paste the id into wrangler.toml
wrangler secret put OAUTH_TOKEN_SECRET   # e.g. openssl rand -hex 32
```

## Test plan

`src/__tests__/worker-oauth.test.ts` — 10 cases: `redirect_uri` allowlist (GET/POST, unknown client), S256 enforcement, full code→token flow asserting **no plaintext at rest** + TTL, PKCE / `redirect_uri` mismatch rejection, and the MCP auth gate accepting valid / rejecting unknown OAuth bearer tokens.

Verified: ✓ node typecheck · ✓ worker typecheck · ✓ worker build · ✓ 43/43 tests.

## Not included (deliberate)

No refresh tokens — on 30-day expiry the client re-runs the OAuth flow. Easy follow-up if longer silent sessions are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)