### PR TITLE
chore(worker): wire deployed OAUTH_KV namespace id into main

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,7 +28,7 @@ command = "npm run build:worker"
 # Then paste the ID below
 [[kv_namespaces]]
 binding = "OAUTH_KV"
-id = "REPLACE_WITH_KV_NAMESPACE_ID"
+id = "7a077b34c5e94d3ba277fee716efe2f0"
 
 # OAuth requires a secret used to encrypt stored Plytix credentials at rest.
 # It is NOT declared here (secrets never live in wrangler.toml). Set it with:


### PR DESCRIPTION
One-line fix to make `main` match production.

PR #22 was squash-merged just as the namespace-id commit was pushed, so `main` kept the `REPLACE_WITH_KV_NAMESPACE_ID` placeholder while the live Worker already runs the provisioned namespace (`7a077b34…`). Without this, a fresh `wrangler deploy` from `main` would deploy an invalid KV binding.

- Sets the real `OAUTH_KV` id in `wrangler.toml`.
- Namespace ids are **not** secret. `OAUTH_TOKEN_SECRET` stays a `wrangler secret` and is not in the repo.
- No code/logic change — production is already running this id (deployed + verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)