### PR TITLE
v0.3.0 feat: add batch product update tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-09
+
+### Added
+- Added `products_batch_update` so agents can apply small product-update batches through
+  the documented product PATCH path, with dry-run validation and per-row failure reporting.
+- Added stdio-only `products_batch_update_manifest` so large local JSON manifests can run
+  without sending manifest bytes through the model context.
+- Added shared batch-update guardrails for SKU resolution, `sku`/`product_id` verification,
+  duplicate detection, request pacing, retry handling, manifest hashing, and separate
+  stdio/Worker payload caps.
+
+### Changed
+- Documented the batch-update implementation plan, REST evidence gate, and Worker parity
+  exception for the stdio-only manifest tool.
+
 ## [0.2.2] - 2026-05-31
 
 Follow-up fixes from post-merge code review. No breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the batch-update implementation plan, REST evidence gate, and Worker parity
   exception for the stdio-only manifest tool.
 
+### Fixed
+- SKU resolution now pages through all search result pages before verification, so duplicate
+  SKU matches cannot hide behind page 1 during batch updates.
+
 ## [0.2.2] - 2026-05-31
 
 Follow-up fixes from post-merge code review. No breaking changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ src/
 |------|-------------|
 | `products_create` | Create a new product (SKU required) |
 | `products_update` | Update product fields and attributes (PATCH) |
+| `products_batch_update` | Update a small batch of products by `product_id` or `sku` (PATCH loop; inline capped) |
+| `products_batch_update_manifest` | Update products from a local JSON manifest (stdio-only; supports dry run) |
 | `products_assign_family` | Assign or unassign family (may cause data loss) |
 | `products_set_attribute` | Set one product attribute atomically |
 | `products_clear_attribute` | Clear one product attribute atomically |

--- a/docs/features/batch-update/PLAN.md
+++ b/docs/features/batch-update/PLAN.md
@@ -1,0 +1,128 @@
+# PLAN - Batch Product Update implementation
+
+## Decisions To Carry Forward
+
+- Build v1 around documented `PATCH /api/v2/products/:product_id`.
+- Keep Step 0 first, but treat it as an acceleration probe. Lack of an async bulk
+  endpoint does not block the feature.
+- Keep all feature docs under `docs/features/batch-update`; avoid implying a native
+  Plytix bulk API.
+- Ship two tools:
+  - `products_batch_update` for inline small batches on stdio and Worker.
+  - `products_batch_update_manifest` for stdio-only local manifests.
+- Use `product_id` for the PATCH target when present and `sku` as the preferred ledger
+  and failure key. Allow both on the same item.
+- Verify `sku` and `product_id` point to the same product before PATCH when both are
+  present.
+- Add `dry_run` to both tools.
+- Keep the 10,000 item cap for manifest runs. Stdio inline runs cap at 250 items and
+  512 KB serialized payload; Worker inline runs cap at 50 items and 256 KB.
+- Long runs must tolerate token expiry, rate pacing, and retryable upstream failures.
+
+## Step 0 - Endpoint Evidence
+
+1. Check the Plytix Postman collection or official API evidence for a supported async
+   product update endpoint.
+2. Record the evidence in `docs/features/batch-update/REST-EVIDENCE.md`:
+   - endpoint paths,
+   - auth/version,
+   - request body,
+   - status/poll shape,
+   - per-row success/failure shape,
+   - conclusion: `use_patch_loop` or `async_endpoint_confirmed`.
+3. Continue with the PATCH-loop implementation unless the async endpoint is fully
+   confirmed from first-party evidence. A browser capture of an internal UI/import
+   endpoint is evidence only; it does not justify shipping against that endpoint in this
+   public MCP repo.
+
+## Step 1 - Shared Types And Helpers
+
+1. Add batch types in `src/types.ts`:
+   - `BatchUpdateItem`
+   - `BatchUpdateFailure`
+   - `BatchUpdateSummary`
+   - `BatchUpdateMetadata`
+   - `BatchUpdateResult`
+2. Create `src/batch/helpers.ts` with pure functions:
+   - `getBatchItemKey(item)`
+   - `buildPatchBody(item)`
+   - `validateBatchItems(items, { maxItems })`
+   - `detectDuplicateTargets(items)`
+   - `parsePlytixErrors(error)`
+   - `aggregateBatchResults(...)`
+   - `measureSerializedBytes(value)`
+3. Keep helpers network-free so most behavior is unit-testable.
+
+## Step 2 - Client Execution
+
+1. In `src/client.ts`, add `resolveProductIdsBySku(skus)`:
+   - use `POST /api/v2/products/search`,
+   - filter by exact `sku in [...]` where supported,
+   - request only minimal fields,
+   - use no `pagination.order`,
+   - keep `page_size <= 100`,
+   - chunk SKU searches to stay within page-size limits,
+   - fail unresolved or ambiguous SKUs per row.
+2. Add `batchUpdateProducts(items, options?)`:
+   - validate inputs,
+   - resolve missing product IDs,
+   - verify all `sku + product_id` pairs by resolving SKU and comparing IDs,
+   - reject post-resolution duplicate product IDs,
+   - PATCH with bounded concurrency and pacing,
+   - refresh auth on expiry/401 during long runs,
+   - retry transient 5xx/timeouts before recording row failure,
+   - return the common `finished`/`rejected` result shape.
+3. Repeat the same methods in `src/worker-client.ts`.
+
+## Step 3 - Tool Surfaces
+
+1. In `src/tools/products.ts`, register:
+   - `products_batch_update({ items, dry_run? })`
+   - `products_batch_update_manifest({ manifest_path, dry_run? })`
+2. Manifest tool behavior:
+   - read UTF-8 JSON from disk,
+   - require a `.json` path and `schema_version: 1`,
+   - reject files over 32 MB,
+   - require an object with `items`,
+   - compute `manifest_sha256`,
+   - pass metadata into the result,
+   - use the 10,000 item cap.
+3. Inline tool behavior:
+   - use the stdio 250 item and 512 KB cap,
+   - return JSON text like existing product write tools.
+4. In `src/worker.ts`, expose only `products_batch_update` with the 50 item and 256 KB
+   cap.
+
+## Step 4 - Tests
+
+1. Add `src/__tests__/batch-update.test.ts`.
+2. Cover validation and duplicate behavior.
+3. Cover manifest parsing, missing files, malformed JSON, metadata, and SHA-256.
+4. Mock client search/PATCH behavior for:
+   - all success,
+   - mixed resolve and patch failures,
+   - `sku + product_id` items,
+   - Plytix structured error parsing,
+   - oversized inline and manifest requests.
+   - dry-run resolution with zero PATCH calls.
+5. Add a Worker tool-list or schema assertion showing manifest is intentionally omitted.
+
+## Step 5 - Docs And Verification
+
+1. Update `CLAUDE.md` tool lists.
+2. Update `docs/features/worker-parity/SPEC.md` counts and intentional stdio-only
+   manifest exception.
+3. Run:
+   - `npm test`
+   - `npm run typecheck`
+   - `npm run typecheck:worker`
+4. With credentials, smoke-test a 2-4 product batch before running any production
+   manifest.
+
+## Notes For Implementation
+
+- Do not add CSV import tools in v1.
+- Do not add job/status tools without a first-party async endpoint.
+- Do not persist idempotency state in this repo; the ETL ledger owns version-aware skip
+  behavior.
+- Keep the implementation boring: search missing IDs, patch products, aggregate results.

--- a/docs/features/batch-update/PLAN.md
+++ b/docs/features/batch-update/PLAN.md
@@ -62,6 +62,7 @@
    - use no `pagination.order`,
    - keep `page_size <= 100`,
    - chunk SKU searches to stay within page-size limits,
+   - page through every chunk until `pagination.pages` is exhausted,
    - fail unresolved or ambiguous SKUs per row.
 2. Add `batchUpdateProducts(items, options?)`:
    - validate inputs,

--- a/docs/features/batch-update/REST-EVIDENCE.md
+++ b/docs/features/batch-update/REST-EVIDENCE.md
@@ -1,0 +1,27 @@
+# REST Evidence - Batch Product Update
+
+> **Conclusion:** `use_patch_loop`
+> **Date:** 2026-06-09
+
+The local API scrape in `docs/solutions/api-quirks/plytix-api.md` confirms documented
+single-product product APIs:
+
+- `POST /api/v2/products`
+- `GET /api/v2/products/:product_id`
+- `PATCH /api/v2/products/:product_id`
+- `DELETE /api/v2/products/:product_id`
+- `POST /api/v2/products/search`
+
+It does not document a public async bulk product update endpoint, job submit endpoint, job
+status endpoint, CSV-import execution endpoint, or import-profile REST API.
+
+Implementation rule:
+
+- Only a supported first-party public API endpoint can switch the implementation to
+  `async_endpoint_confirmed`.
+- A browser capture of private UI/import endpoints is evidence only and does not justify
+  shipping a public MCP tool against that endpoint.
+- Third-party wrapper behavior is not enough to select an async implementation.
+
+Until first-party evidence proves otherwise, v1 uses bounded, paced single-product PATCH
+calls behind the batch-update contract.

--- a/docs/features/batch-update/SPEC.md
+++ b/docs/features/batch-update/SPEC.md
@@ -1,0 +1,315 @@
+# SPEC - Batch Product Update tools
+
+> **Status:** Design approved after review
+> **Date:** 2026-06-09
+> **Consumer:** supplyline-etl B-projection backfill manifest contract
+
+## Summary
+
+Add manifest-driven batch product update tools over documented Plytix product PATCH
+operations.
+
+This is not a CSV-import automation layer, and v1 does not depend on undocumented
+bulk/import/job endpoints. If a supported async bulk endpoint is later confirmed, the
+client may use it as an internal optimization while preserving the same response
+contract.
+
+Tools:
+
+- **`products_batch_update`** - inline small/interactive batch update; available on stdio
+  and the Cloudflare Worker.
+- **`products_batch_update_manifest`** - stdio-only local manifest update; reads payloads
+  from disk so large validated payload bytes never flow through the model context.
+
+The work was prompted by a real consumer: the supplyline-etl `LMI-PD`
+`box_n`/`opt_n`/`google_detail` backfill. The current sample is about 240 products, and
+the larger series need remains real. A bounded PATCH loop is acceptable even if it takes
+minutes on stdio.
+
+Docs live under `docs/features/batch-update/` to avoid implying a confirmed native
+Plytix bulk-write API.
+
+## Load-bearing constraint
+
+**Do not thread validated payload bytes through the model's context.**
+
+The failure mode is not only HTTP round trips. Large `google_detail` payloads assembled
+inside one giant tool call still burn context and make the agent brittle. Consequences:
+
+- Inline `items[]` is only for compact interactive batches.
+- Backfills use `products_batch_update_manifest`, where the tool reads a JSON manifest
+  from disk and submits the already-validated items.
+- The ETL owns projection, validation, and its version-aware `did_push` ledger. This
+  server remains stateless.
+
+## Item Contract
+
+Update-only. No bulk create, delete, import-profile, or CSV-import execution in v1.
+
+Each item:
+
+```ts
+interface BatchUpdateItem {
+  product_id?: string;   // preferred PATCH target when known
+  sku?: string;          // used to resolve product_id when needed; preferred result key
+  label?: string;
+  status?: string;
+  attributes?: Record<string, unknown>; // null clears an attribute
+}
+```
+
+Validation before any write:
+
+- At least one of `product_id` or `sku` is required.
+- Both `product_id` and `sku` are allowed. This is the expected manifest shape: patch by
+  `product_id`, report by `sku`.
+- At least one of `label`, `status`, or non-empty `attributes` is required.
+- `attributes` must be a plain object when present.
+- `attributes: {}` is invalid unless `label` or `status` is present.
+- `null` values inside `attributes` are allowed because they clear attributes.
+- `sku` itself is not patchable in v1.
+- Attribute format/value validation is out of scope; Plytix rejects are surfaced per row.
+- Duplicate or conflicting identities are rejected before any mutation:
+  duplicate `sku`, duplicate `product_id`, post-resolution duplicate `product_id`,
+  same `sku` with conflicting `product_id`, or same `product_id` under conflicting `sku`.
+- When both `sku` and `product_id` are present, resolve the SKU and verify it maps to the
+  same product before PATCH. Mismatches become row failures with `stage: "verify"` and
+  that row is skipped.
+
+If any item is structurally invalid, reject the whole call and return the offending
+indices. Do not partially apply a structurally invalid batch.
+
+## Manifest Contract
+
+`products_batch_update_manifest` input:
+
+```ts
+{
+  manifest_path: string
+}
+```
+
+Manifest file:
+
+```jsonc
+{
+  "schema_version": 1,
+  "series_id": "LMI-PD",
+  "config_snapshot_hash": "<hash>",
+  "items": [
+    {
+      "sku": "LMI-PD041929NI",
+      "product_id": "5e0110bb...",
+      "attributes": {
+        "opt_1": "...",
+        "google_detail": "..."
+      }
+    }
+  ]
+}
+```
+
+Rules:
+
+- `schema_version: 1` is required.
+- `items` follows the same item contract as inline input.
+- `series_id` and `config_snapshot_hash` are metadata only. Echo them back for the ETL
+  ledger; do not make tool behavior depend on them.
+- Compute and return `manifest_sha256` so the caller can record exactly what was pushed.
+- Hard cap manifest submissions at **10,000 items**. This is a runaway guardrail; known
+  Supplyline series sizes are below it. Split larger pushes explicitly.
+- Read UTF-8 JSON only.
+- Require a `.json` path.
+- Reject files larger than **32 MB**.
+- Never echo manifest payload contents in errors. Return only metadata, counts, row keys,
+  and error messages.
+
+The Cloudflare Worker does not expose this tool because it cannot read the caller's local
+filesystem. This is an intentional stdio-only exception to worker parity.
+
+## Inline Contract
+
+`products_batch_update` input:
+
+```ts
+{
+  items: BatchUpdateItem[],
+  dry_run?: boolean
+}
+```
+
+Rules:
+
+- Same validation and response shape as the manifest tool.
+- Stdio inline cap: **250 items** and **512 KB** serialized payload.
+- Worker inline cap: **50 items** and **256 KB** serialized payload.
+- Large or text-heavy updates should use the stdio manifest tool even when under the item
+  cap.
+
+`products_batch_update_manifest` also accepts `dry_run?: boolean`.
+
+Dry run:
+
+- parses and validates the manifest/input,
+- computes `manifest_sha256` when applicable,
+- resolves SKUs,
+- verifies `sku`/`product_id` pairs,
+- detects duplicate targets,
+- returns the same result shape with `dry_run: true`,
+- performs zero PATCH calls.
+
+## Mechanism
+
+Primary v1 implementation uses documented product APIs from
+`docs/solutions/api-quirks/plytix-api.md`:
+
+1. Validate all items.
+2. Resolve missing `product_id` values by exact SKU search:
+   `POST /api/v2/products/search`.
+3. PATCH each product with bounded concurrency:
+   `PATCH /api/v2/products/:product_id`.
+4. Reuse existing auth, timeout, 401 retry, and 429 backoff in `client.ts` and
+   `worker-client.ts`.
+5. Return per-key success/failure results.
+
+Step 0 remains first, but it is an acceleration probe, not a build gate:
+
+- Check whether Plytix exposes a supported first-party async product update endpoint via
+  the Postman collection or official API evidence.
+- If confirmed, record the submit/status/result shapes and optionally implement it behind
+  the same batch-update contract.
+- If not confirmed, ship the documented PATCH loop. Do not infer endpoints from
+  third-party wrappers alone.
+- A browser capture of an internal UI/import endpoint is not enough to set
+  `async_endpoint_confirmed`. Private UI/import endpoints are evidence only; the
+  conclusion remains `use_patch_loop`.
+
+## Response Shapes
+
+Structural rejection:
+
+```ts
+{
+  status: "rejected",
+  summary: { total: number, succeeded: 0, failed: number, skipped: number },
+  failures: Array<{
+    index: number,
+    key: string,
+    stage: "validation" | "duplicate",
+    errors: Array<{ field?: string, msg: string }>
+  }>,
+  metadata?: BatchMetadata
+}
+```
+
+Completed run:
+
+```ts
+{
+  status: "finished",
+  dry_run?: boolean,
+  summary: { total: number, succeeded: number, failed: number, skipped: number },
+  failures: Array<{
+    index: number,
+    key: string,
+    product_id?: string,
+    stage: "resolve" | "verify" | "patch",
+    errors: Array<{ field?: string, msg: string }>
+  }>,
+  metadata?: BatchMetadata
+}
+```
+
+```ts
+interface BatchMetadata {
+  series_id?: string;
+  config_snapshot_hash?: string;
+  manifest_sha256?: string;
+}
+```
+
+`key` is `sku` when present, otherwise `product_id`. Never report blanket success when a
+row failed.
+
+No `running` state and no synthetic job handles in v1. If a real async endpoint is later
+confirmed, add status/polling only with the actual API shape.
+
+Result rules:
+
+- Validation or duplicate batch-level errors return `status: "rejected"` with no API
+  mutations.
+- Unresolved SKU or `sku`/`product_id` mismatch is a row failure and skipped PATCH.
+- PATCH failure is a row failure.
+- Success only means the PATCH request succeeded for that row.
+
+## Error Handling
+
+- Structural validation errors reject the whole call before any API request.
+- SKU resolution failures are row failures with `stage: "resolve"`.
+- SKU/product ID mismatches are row failures with `stage: "verify"`.
+- Plytix PATCH rejects are row failures with `stage: "patch"` and the Plytix
+  `{ field, msg }` details when available.
+- Unexpected or unparsable Plytix errors still include a clear message and the row key.
+- `429` and token refresh behavior stay in the existing request path. Long manifest runs
+  must tolerate token expiry through 401 refresh/retry, and request pacing must limit
+  concurrency rather than firing all PATCHes at once.
+- Retry transient 5xx/timeouts a small number of times; after exhaustion, record a row
+  failure.
+- `google_detail` feeds customer-facing Google Merchant output; surface failures
+  prominently.
+- Absent custom attributes on read-back are not proof of unchanged values, because Plytix
+  omits empty/absent custom attributes in search responses.
+
+## File Plan
+
+| Layer | Change |
+|---|---|
+| `src/types.ts` | Add batch item/result/failure metadata types. |
+| `src/batch/helpers.ts` *(new)* | Pure validation, duplicate detection, metadata shaping, byte-size checks, error parsing, concurrency helper. |
+| `src/client.ts` | Add `resolveProductIdsBySku()` and `batchUpdateProducts()` using documented search + PATCH. |
+| `src/worker-client.ts` | Add the same methods for Worker runtime. |
+| `src/tools/products.ts` | Register `products_batch_update` and stdio-only `products_batch_update_manifest`. |
+| `src/worker.ts` | Mirror `products_batch_update` only. |
+| `src/__tests__/batch-update.test.ts` *(new)* | Unit tests for helpers and mocked client execution. |
+| `CLAUDE.md`, `docs/features/worker-parity/SPEC.md` | Document the new tools and stdio-only manifest exception. |
+
+## Testing
+
+Unit tests with no live API:
+
+- Validation: missing key, missing update fields, non-object attributes, empty
+  attributes-only update, duplicate keys, invalid manifest JSON, oversized
+  inline/manifest requests.
+- `product_id` + `sku` together is valid and reports by `sku`.
+- SKU resolution and verification: found, not found, duplicate SKU result, mismatch
+  between `sku` and `product_id`, and fallback/error mapping.
+- PATCH aggregation: mixed successes/failures, preserved indices, correct
+  `succeeded`/`failed`/`skipped` counts.
+- Error parsing: Plytix `{ error: { errors: [...] } }`, top-level messages, and unknown
+  errors.
+- Manifest read: valid file, missing file, non-JSON path, oversized file, malformed JSON,
+  schema version, metadata echo, SHA-256.
+- Dry run performs resolution/verification but zero PATCH calls.
+- Worker parity: Worker exposes inline batch update with lower caps and intentionally
+  omits manifest.
+
+Live verification after implementation:
+
+1. Run Step 0 probe and record whether a real async endpoint exists.
+2. Run a tiny 2-4 product batch through documented PATCH.
+3. Confirm returned failures/successes match Plytix state before using the tool on the
+   full manifest.
+
+## Review Decisions
+
+1. Include the off-context disk-submit path in v1, but expose it as
+   `products_batch_update_manifest` instead of a `manifest_path` branch on the Worker-
+   mirrored inline tool. This keeps the APIs smaller and avoids a remote input that can
+   never work.
+2. Use **10,000** as the manifest cap. The known sample is about 240, the previously
+   discussed 620 still fits easily, and a larger-than-10,000 push should be deliberately
+   split.
+3. Rename the public feature/tools from "bulk" to "batch" to avoid implying a confirmed
+   Plytix bulk-write API.
+4. Do not ship `products_bulk_status` or any job handle until a real async endpoint is
+   proven.

--- a/docs/features/batch-update/SPEC.md
+++ b/docs/features/batch-update/SPEC.md
@@ -165,7 +165,8 @@ Primary v1 implementation uses documented product APIs from
 
 1. Validate all items.
 2. Resolve missing `product_id` values by exact SKU search:
-   `POST /api/v2/products/search`.
+   `POST /api/v2/products/search`, with no `pagination.order`, `page_size <= 100`,
+   and paging through each chunk until `pagination.pages` is exhausted.
 3. PATCH each product with bounded concurrency:
    `PATCH /api/v2/products/:product_id`.
 4. Reuse existing auth, timeout, 401 retry, and 429 backoff in `client.ts` and

--- a/docs/features/worker-parity/SPEC.md
+++ b/docs/features/worker-parity/SPEC.md
@@ -6,11 +6,16 @@
 
 The Cloudflare Worker MCP server now exposes the full API-backed tool surface.
 
-- `stdio`: 47 tools
-- `remote worker`: 44 tools
-- intentional remote omissions: `identifier_detect`, `identifier_normalize`, `match_score`
+- `stdio`: 49 tools
+- `remote worker`: 45 tools
+- intentional remote omissions: `identifier_detect`, `identifier_normalize`, `match_score`,
+  `products_batch_update_manifest`
 
-Those three tools remain stdio-only because they are pure local utilities. Remote clients should use `products_lookup`, which already incorporates the same identifier logic for the practical lookup flow.
+The three identifier tools remain stdio-only because they are pure local utilities. Remote
+clients should use `products_lookup`, which already incorporates the same identifier logic
+for the practical lookup flow. `products_batch_update_manifest` is stdio-only because it
+reads a user-local JSON file; the Worker has no caller filesystem access and exposes the
+inline `products_batch_update` tool with lower caps instead.
 
 ## Current Parity Rules
 
@@ -26,7 +31,8 @@ Those three tools remain stdio-only because they are pure local utilities. Remot
 | `identifier_detect` | Pure utility for analyzing raw identifier format |
 | `identifier_normalize` | Pure utility for string normalization |
 | `match_score` | Pure utility for local identifier-to-product scoring |
+| `products_batch_update_manifest` | Reads a local JSON manifest from the user's filesystem |
 
 ## Historical Note
 
-The earlier worker parity gap around product writes, attribute metadata reads, category linking, and attribute validation has already been closed. This document now records the steady-state contract: remote mirrors stdio except for the three local identifier helpers above.
+The earlier worker parity gap around product writes, attribute metadata reads, category linking, and attribute validation has already been closed. This document now records the steady-state contract: remote mirrors stdio except for the local identifier helpers and the local-filesystem manifest batch tool above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plytix-mcp-server",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "type": "module",
   "description": "MCP server for Plytix PIM API integration. Enables AI assistants to read, write, and manage product data, assets, categories, and relationships.",
   "keywords": [

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -3,17 +3,44 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import worker from '../worker.js';
+import { PlytixClient } from '../client.js';
+import { WorkerPlytixClient } from '../worker-client.js';
 import { readBatchManifest } from '../batch/manifest.js';
 import { executeBatchUpdate, type BatchUpdateOperations } from '../batch/runner.js';
 import {
   STDIO_INLINE_MAX_BYTES,
   validateBatchItems,
 } from '../batch/helpers.js';
-import { PlytixError, type PlytixProduct, type PlytixResult } from '../types.js';
+import {
+  PlytixError,
+  type PlytixProduct,
+  type PlytixResult,
+  type PlytixSearchBody,
+} from '../types.js';
 
 const productResult = (id: string): PlytixResult<PlytixProduct> => ({
   data: [{ id, modified: '2026-06-09T00:00:00Z' }],
 });
+
+const skuResolutionPage = (page: number): PlytixResult<PlytixProduct> => {
+  if (page === 1) {
+    return {
+      data: [
+        ...Array.from({ length: 99 }, (_, index) => ({
+          id: `product-${index + 1}`,
+          sku: `SKU${index + 1}`,
+        })),
+        { id: 'dup-product-1', sku: 'DUP-SKU' },
+      ],
+      pagination: { page: 1, page_size: 100, total: 101, pages: 2 },
+    };
+  }
+
+  return {
+    data: [{ id: 'dup-product-2', sku: 'DUP-SKU' }],
+    pagination: { page: 2, page_size: 100, total: 101, pages: 2 },
+  };
+};
 
 function makeOps(args?: {
   resolved?: Record<string, Array<{ id: string; sku?: string }>>;
@@ -185,6 +212,44 @@ describe('executeBatchUpdate', () => {
       field: 'attributes.google_detail',
       msg: 'too long',
     });
+  });
+});
+
+describe('SKU resolution pagination', () => {
+  const skus = ['DUP-SKU', ...Array.from({ length: 99 }, (_, index) => `SKU${index + 1}`)];
+
+  it('stdio client pages through all SKU matches before verification', async () => {
+    const client = new PlytixClient({ apiKey: 'key', apiPassword: 'password' });
+    const searchProducts = vi.fn(async (body: PlytixSearchBody) =>
+      skuResolutionPage(body.pagination?.page ?? 1)
+    );
+    client.searchProducts = searchProducts as typeof client.searchProducts;
+
+    const resolved = await client.resolveProductIdsBySku(skus);
+
+    expect(searchProducts).toHaveBeenCalledTimes(2);
+    expect(searchProducts.mock.calls.map(([body]) => body.pagination?.page)).toEqual([1, 2]);
+    expect(resolved.get('DUP-SKU')?.map((product) => product.id)).toEqual([
+      'dup-product-1',
+      'dup-product-2',
+    ]);
+  });
+
+  it('Worker client pages through all SKU matches before verification', async () => {
+    const client = new WorkerPlytixClient({ apiKey: 'key', apiPassword: 'password' });
+    const searchProducts = vi.fn(async (body: PlytixSearchBody) =>
+      skuResolutionPage(body.pagination?.page ?? 1)
+    );
+    client.searchProducts = searchProducts as typeof client.searchProducts;
+
+    const resolved = await client.resolveProductIdsBySku(skus);
+
+    expect(searchProducts).toHaveBeenCalledTimes(2);
+    expect(searchProducts.mock.calls.map(([body]) => body.pagination?.page)).toEqual([1, 2]);
+    expect(resolved.get('DUP-SKU')?.map((product) => product.id)).toEqual([
+      'dup-product-1',
+      'dup-product-2',
+    ]);
   });
 });
 

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -1,0 +1,256 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import worker from '../worker.js';
+import { readBatchManifest } from '../batch/manifest.js';
+import { executeBatchUpdate, type BatchUpdateOperations } from '../batch/runner.js';
+import {
+  STDIO_INLINE_MAX_BYTES,
+  validateBatchItems,
+} from '../batch/helpers.js';
+import { PlytixError, type PlytixProduct, type PlytixResult } from '../types.js';
+
+const productResult = (id: string): PlytixResult<PlytixProduct> => ({
+  data: [{ id, modified: '2026-06-09T00:00:00Z' }],
+});
+
+function makeOps(args?: {
+  resolved?: Record<string, Array<{ id: string; sku?: string }>>;
+  update?: (productId: string) => Promise<PlytixResult<PlytixProduct>>;
+}): BatchUpdateOperations & {
+  resolveProductIdsBySku: ReturnType<typeof vi.fn>;
+  updateProduct: ReturnType<typeof vi.fn>;
+} {
+  return {
+    resolveProductIdsBySku: vi.fn(async (skus: string[]) => {
+      const map = new Map<string, Array<{ id: string; sku?: string }>>();
+      for (const sku of skus) {
+        map.set(sku, args?.resolved?.[sku] ?? []);
+      }
+      return map;
+    }),
+    updateProduct: vi.fn(async (productId: string) =>
+      args?.update ? args.update(productId) : productResult(productId)
+    ),
+  };
+}
+
+describe('batch update validation', () => {
+  it('allows sku plus product_id and reports no structural failures', () => {
+    const result = validateBatchItems(
+      [
+        {
+          sku: 'LMI-PD041929NI',
+          product_id: 'product-1',
+          attributes: { google_detail: 'copy' },
+        },
+      ],
+      { maxItems: 250 }
+    );
+
+    expect(result.failures).toEqual([]);
+    expect(result.items[0]).toMatchObject({ sku: 'LMI-PD041929NI', product_id: 'product-1' });
+  });
+
+  it('rejects missing identity, non-object attributes, and empty attributes-only updates', () => {
+    const result = validateBatchItems(
+      [
+        { attributes: { foo: 'bar' } },
+        { sku: 'A', attributes: [] },
+        { sku: 'B', attributes: {} },
+      ],
+      { maxItems: 250 }
+    );
+
+    expect(result.failures.map((failure) => failure.index)).toEqual([0, 1, 1, 2]);
+    expect(result.failures.every((failure) => failure.stage === 'validation')).toBe(true);
+  });
+
+  it('rejects duplicate sku and duplicate product_id before writes', () => {
+    const result = validateBatchItems(
+      [
+        { sku: 'A', product_id: '1', label: 'one' },
+        { sku: 'A', product_id: '2', label: 'two' },
+        { sku: 'B', product_id: '2', label: 'three' },
+      ],
+      { maxItems: 250 }
+    );
+
+    expect(result.failures.some((failure) => failure.stage === 'duplicate')).toBe(true);
+    expect(result.failures.some((failure) => failure.errors[0]?.field === 'sku')).toBe(true);
+    expect(result.failures.some((failure) => failure.errors[0]?.field === 'product_id')).toBe(true);
+  });
+
+  it('enforces serialized byte caps for inline calls', () => {
+    const result = validateBatchItems(
+      [{ product_id: '1', attributes: { google_detail: 'x'.repeat(STDIO_INLINE_MAX_BYTES) } }],
+      { maxItems: 250, maxBytes: 1024 }
+    );
+
+    expect(result.failures[0]?.errors[0]?.msg).toContain('inline payload');
+  });
+});
+
+describe('executeBatchUpdate', () => {
+  it('dry-runs resolution and verification without PATCH calls', async () => {
+    const ops = makeOps({ resolved: { SKU1: [{ id: 'product-1', sku: 'SKU1' }] } });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'SKU1', product_id: 'product-1', label: 'New label' }],
+      { maxItems: 250, dryRun: true }
+    );
+
+    expect(result).toMatchObject({
+      status: 'finished',
+      dry_run: true,
+      summary: { total: 1, succeeded: 0, failed: 0, skipped: 1 },
+    });
+    expect(ops.resolveProductIdsBySku).toHaveBeenCalledWith(['SKU1']);
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('skips rows when sku and product_id disagree', async () => {
+    const ops = makeOps({ resolved: { SKU1: [{ id: 'resolved-product', sku: 'SKU1' }] } });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'SKU1', product_id: 'wrong-product', label: 'New label' }],
+      { maxItems: 250 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toEqual({ total: 1, succeeded: 0, failed: 1, skipped: 1 });
+    expect(result.failures[0]).toMatchObject({ stage: 'verify', key: 'SKU1' });
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('rejects post-resolution duplicate product targets before PATCH calls', async () => {
+    const ops = makeOps({
+      resolved: {
+        SKU1: [{ id: 'same-product', sku: 'SKU1' }],
+        SKU2: [{ id: 'same-product', sku: 'SKU2' }],
+      },
+    });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [
+        { sku: 'SKU1', label: 'One' },
+        { sku: 'SKU2', label: 'Two' },
+      ],
+      { maxItems: 250 }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.failures.every((failure) => failure.stage === 'duplicate')).toBe(true);
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('aggregates mixed resolve, patch success, and structured patch failures', async () => {
+    const ops = makeOps({
+      resolved: {
+        GOOD: [{ id: 'good-product', sku: 'GOOD' }],
+        BAD: [{ id: 'bad-product', sku: 'BAD' }],
+      },
+      update: async (productId) => {
+        if (productId === 'bad-product') {
+          throw new PlytixError(
+            'Request failed',
+            422,
+            JSON.stringify({
+              error: { errors: [{ field: 'attributes.google_detail', msg: 'too long' }] },
+            })
+          );
+        }
+        return productResult(productId);
+      },
+    });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [
+        { sku: 'GOOD', attributes: { google_detail: 'ok' } },
+        { sku: 'MISSING', label: 'Missing' },
+        { sku: 'BAD', attributes: { google_detail: 'bad' } },
+      ],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toEqual({ total: 3, succeeded: 1, failed: 2, skipped: 1 });
+    expect(result.failures.map((failure) => failure.stage)).toEqual(['resolve', 'patch']);
+    expect(result.failures[1]?.errors[0]).toEqual({
+      field: 'attributes.google_detail',
+      msg: 'too long',
+    });
+  });
+});
+
+describe('batch manifest parsing', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  async function writeManifest(name: string, value: unknown) {
+    tempDir = await mkdtemp(join(tmpdir(), 'plytix-batch-'));
+    const path = join(tempDir, name);
+    await writeFile(path, JSON.stringify(value), 'utf8');
+    return path;
+  }
+
+  it('reads schema_version 1 manifests and returns metadata plus sha256', async () => {
+    const path = await writeManifest('manifest.json', {
+      schema_version: 1,
+      series_id: 'LMI-PD',
+      config_snapshot_hash: 'abc123',
+      items: [{ sku: 'SKU1', product_id: 'product-1', label: 'Label' }],
+    });
+
+    const manifest = await readBatchManifest(path);
+
+    expect(manifest.items).toHaveLength(1);
+    expect(manifest.metadata).toMatchObject({
+      series_id: 'LMI-PD',
+      config_snapshot_hash: 'abc123',
+    });
+    expect(manifest.metadata.manifest_sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('rejects non-json manifests and missing schema_version', async () => {
+    const txtPath = await writeManifest('manifest.txt', {
+      schema_version: 1,
+      items: [],
+    });
+    await expect(readBatchManifest(txtPath)).rejects.toThrow('.json');
+
+    const jsonPath = await writeManifest('manifest.json', { items: [] });
+    await expect(readBatchManifest(jsonPath)).rejects.toThrow('schema_version');
+  });
+});
+
+describe('worker batch-update surface', () => {
+  it('exposes inline batch update and omits the stdio-only manifest tool', async () => {
+    const response = await worker.fetch(
+      new Request('https://mcp.example.com/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any
+    );
+
+    const body = await response.json() as { result: { tools: Array<{ name: string }> } };
+    const toolNames = body.result.tools.map((tool) => tool.name);
+
+    expect(toolNames).toContain('products_batch_update');
+    expect(toolNames).not.toContain('products_batch_update_manifest');
+  });
+});

--- a/src/batch/helpers.ts
+++ b/src/batch/helpers.ts
@@ -1,0 +1,379 @@
+import type {
+  BatchUpdateErrorDetail,
+  BatchUpdateFailure,
+  BatchUpdateItem,
+  BatchUpdateMetadata,
+  BatchUpdateResult,
+} from '../types.js';
+
+export const STDIO_INLINE_MAX_ITEMS = 250;
+export const WORKER_INLINE_MAX_ITEMS = 50;
+export const MANIFEST_MAX_ITEMS = 10_000;
+export const STDIO_INLINE_MAX_BYTES = 512 * 1024;
+export const WORKER_INLINE_MAX_BYTES = 256 * 1024;
+export const MANIFEST_MAX_BYTES = 32 * 1024 * 1024;
+export const DEFAULT_BATCH_CONCURRENCY = 3;
+export const DEFAULT_BATCH_REQUEST_DELAY_MS = 250;
+
+export interface BatchValidationOptions {
+  maxItems: number;
+  maxBytes?: number;
+}
+
+export interface BatchValidationResult {
+  items: BatchUpdateItem[];
+  failures: BatchUpdateFailure[];
+}
+
+export interface PatchBody {
+  label?: string;
+  status?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export function getBatchItemKey(item: Partial<BatchUpdateItem> | undefined): string {
+  return item?.sku || item?.product_id || 'batch';
+}
+
+export function measureSerializedBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function makeFailure(
+  index: number,
+  item: Partial<BatchUpdateItem> | undefined,
+  stage: BatchUpdateFailure['stage'],
+  msg: string,
+  field?: string
+): BatchUpdateFailure {
+  return {
+    index,
+    key: getBatchItemKey(item),
+    ...(item?.product_id ? { product_id: item.product_id } : {}),
+    stage,
+    errors: [{ ...(field ? { field } : {}), msg }],
+  };
+}
+
+export function buildPatchBody(item: BatchUpdateItem): PatchBody {
+  const body: PatchBody = {};
+  if (item.label !== undefined) body.label = item.label;
+  if (item.status !== undefined) body.status = item.status;
+  if (item.attributes !== undefined && Object.keys(item.attributes).length > 0) {
+    body.attributes = item.attributes;
+  }
+  return body;
+}
+
+export function validateBatchItems(
+  input: unknown,
+  options: BatchValidationOptions
+): BatchValidationResult {
+  const failures: BatchUpdateFailure[] = [];
+
+  if (!Array.isArray(input)) {
+    return {
+      items: [],
+      failures: [makeFailure(-1, undefined, 'validation', 'items must be an array', 'items')],
+    };
+  }
+
+  if (input.length > options.maxItems) {
+    failures.push(
+      makeFailure(
+        -1,
+        undefined,
+        'validation',
+        `batch has ${input.length} items; max is ${options.maxItems}`,
+        'items'
+      )
+    );
+  }
+
+  if (options.maxBytes !== undefined) {
+    const bytes = measureSerializedBytes(input);
+    if (bytes > options.maxBytes) {
+      failures.push(
+        makeFailure(
+          -1,
+          undefined,
+          'validation',
+          `inline payload is ${bytes} bytes; max is ${options.maxBytes}`,
+          'items'
+        )
+      );
+    }
+  }
+
+  const items: BatchUpdateItem[] = [];
+  input.forEach((raw, index) => {
+    if (!isPlainObject(raw)) {
+      failures.push(makeFailure(index, undefined, 'validation', 'item must be an object'));
+      return;
+    }
+
+    const item = raw as Partial<BatchUpdateItem>;
+    const normalized: BatchUpdateItem = {};
+
+    if (item.sku !== undefined) {
+      if (typeof item.sku !== 'string' || item.sku.trim() === '') {
+        failures.push(makeFailure(index, item, 'validation', 'sku must be a non-empty string', 'sku'));
+      } else {
+        normalized.sku = item.sku;
+      }
+    }
+
+    if (item.product_id !== undefined) {
+      if (typeof item.product_id !== 'string' || item.product_id.trim() === '') {
+        failures.push(
+          makeFailure(index, item, 'validation', 'product_id must be a non-empty string', 'product_id')
+        );
+      } else {
+        normalized.product_id = item.product_id;
+      }
+    }
+
+    if (!normalized.sku && !normalized.product_id) {
+      failures.push(
+        makeFailure(index, item, 'validation', 'at least one of sku or product_id is required')
+      );
+    }
+
+    if (item.label !== undefined) {
+      if (typeof item.label !== 'string') {
+        failures.push(makeFailure(index, item, 'validation', 'label must be a string', 'label'));
+      } else {
+        normalized.label = item.label;
+      }
+    }
+
+    if (item.status !== undefined) {
+      if (typeof item.status !== 'string') {
+        failures.push(makeFailure(index, item, 'validation', 'status must be a string', 'status'));
+      } else {
+        normalized.status = item.status;
+      }
+    }
+
+    if (item.attributes !== undefined) {
+      if (!isPlainObject(item.attributes)) {
+        failures.push(
+          makeFailure(index, item, 'validation', 'attributes must be an object', 'attributes')
+        );
+      } else {
+        normalized.attributes = item.attributes;
+      }
+    }
+
+    const hasAttributes =
+      normalized.attributes !== undefined && Object.keys(normalized.attributes).length > 0;
+    if (
+      normalized.label === undefined &&
+      normalized.status === undefined &&
+      !hasAttributes
+    ) {
+      failures.push(
+        makeFailure(
+          index,
+          item,
+          'validation',
+          'at least one update field is required: label, status, or non-empty attributes'
+        )
+      );
+    }
+
+    items[index] = normalized;
+  });
+
+  failures.push(...detectDuplicateInputs(items));
+
+  return { items, failures };
+}
+
+export function detectDuplicateInputs(items: BatchUpdateItem[]): BatchUpdateFailure[] {
+  const failures: BatchUpdateFailure[] = [];
+  const bySku = new Map<string, number[]>();
+  const byProductId = new Map<string, number[]>();
+
+  items.forEach((item, index) => {
+    if (item?.sku) {
+      bySku.set(item.sku, [...(bySku.get(item.sku) ?? []), index]);
+    }
+    if (item?.product_id) {
+      byProductId.set(item.product_id, [...(byProductId.get(item.product_id) ?? []), index]);
+    }
+  });
+
+  for (const [sku, indices] of bySku) {
+    if (indices.length > 1) {
+      for (const index of indices) {
+        failures.push(
+          makeFailure(index, items[index], 'duplicate', `duplicate sku in batch: ${sku}`, 'sku')
+        );
+      }
+    }
+  }
+
+  for (const [productId, indices] of byProductId) {
+    if (indices.length > 1) {
+      for (const index of indices) {
+        failures.push(
+          makeFailure(
+            index,
+            items[index],
+            'duplicate',
+            `duplicate product_id in batch: ${productId}`,
+            'product_id'
+          )
+        );
+      }
+    }
+  }
+
+  return failures;
+}
+
+export function detectDuplicateResolvedTargets(
+  rows: Array<{ index: number; item: BatchUpdateItem; productId: string }>
+): BatchUpdateFailure[] {
+  const byProductId = new Map<string, Array<{ index: number; item: BatchUpdateItem }>>();
+  for (const row of rows) {
+    byProductId.set(row.productId, [
+      ...(byProductId.get(row.productId) ?? []),
+      { index: row.index, item: row.item },
+    ]);
+  }
+
+  const failures: BatchUpdateFailure[] = [];
+  for (const [productId, matches] of byProductId) {
+    if (matches.length > 1) {
+      for (const match of matches) {
+        failures.push(
+          makeFailure(
+            match.index,
+            match.item,
+            'duplicate',
+            `post-resolution duplicate product_id in batch: ${productId}`,
+            'product_id'
+          )
+        );
+      }
+    }
+  }
+  return failures;
+}
+
+export function parsePlytixErrors(error: unknown): BatchUpdateErrorDetail[] {
+  const response = error && typeof error === 'object' && 'response' in error
+    ? (error as { response?: unknown }).response
+    : undefined;
+  const parsed = parseErrorPayload(response) ?? parseErrorPayload(error);
+
+  const details = parsed?.error?.errors;
+  if (Array.isArray(details) && details.length > 0) {
+    return details.map((detail) => ({
+      ...(typeof detail?.field === 'string' ? { field: detail.field } : {}),
+      msg: typeof detail?.msg === 'string' ? detail.msg : JSON.stringify(detail),
+    }));
+  }
+
+  const message =
+    (typeof parsed?.error?.msg === 'string' && parsed.error.msg) ||
+    (typeof parsed?.msg === 'string' && parsed.msg) ||
+    (error instanceof Error ? error.message : undefined) ||
+    'Unknown Plytix error';
+  return [{ msg: message }];
+}
+
+function parseErrorPayload(value: unknown): any {
+  if (!value) return undefined;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof value === 'object') return value;
+  return undefined;
+}
+
+export function rejectedResult(
+  total: number,
+  failures: BatchUpdateFailure[],
+  metadata?: BatchUpdateMetadata
+): BatchUpdateResult {
+  return {
+    status: 'rejected',
+    summary: {
+      total,
+      succeeded: 0,
+      failed: failures.length,
+      skipped: total,
+    },
+    failures,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+export function finishedResult(args: {
+  total: number;
+  succeeded: number;
+  failures: BatchUpdateFailure[];
+  skipped: number;
+  dryRun?: boolean;
+  metadata?: BatchUpdateMetadata;
+}): BatchUpdateResult {
+  return {
+    status: 'finished',
+    ...(args.dryRun ? { dry_run: true } : {}),
+    summary: {
+      total: args.total,
+      succeeded: args.succeeded,
+      failed: args.failures.length,
+      skipped: args.skipped,
+    },
+    failures: args.failures,
+    ...(args.metadata ? { metadata: args.metadata } : {}),
+  };
+}
+
+export async function runWithConcurrency<T, R>(
+  items: T[],
+  options: { concurrency: number; requestDelayMs: number },
+  handler: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  let nextStartAt = Date.now();
+
+  async function reserveStartSlot(): Promise<void> {
+    const startAt = Math.max(Date.now(), nextStartAt);
+    nextStartAt = startAt + options.requestDelayMs;
+    const delayMs = startAt - Date.now();
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      await reserveStartSlot();
+      results[currentIndex] = await handler(items[currentIndex]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(options.concurrency, Math.max(items.length, 1)) },
+    () => worker()
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/src/batch/manifest.ts
+++ b/src/batch/manifest.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto';
+import { stat, readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import type { BatchUpdateItem, BatchUpdateMetadata } from '../types.js';
+import { MANIFEST_MAX_BYTES } from './helpers.js';
+
+export interface BatchManifest {
+  items: BatchUpdateItem[];
+  metadata: BatchUpdateMetadata;
+}
+
+export async function readBatchManifest(manifestPath: string): Promise<BatchManifest> {
+  if (extname(manifestPath).toLowerCase() !== '.json') {
+    throw new Error('manifest_path must point to a .json file');
+  }
+
+  const info = await stat(manifestPath);
+  if (!info.isFile()) {
+    throw new Error('manifest_path must point to a file');
+  }
+  if (info.size > MANIFEST_MAX_BYTES) {
+    throw new Error(`manifest file is ${info.size} bytes; max is ${MANIFEST_MAX_BYTES}`);
+  }
+
+  const bytes = await readFile(manifestPath);
+  const manifestSha256 = createHash('sha256').update(bytes).digest('hex');
+
+  let text: string;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error('manifest file must be valid UTF-8');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error('manifest file must contain valid JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('manifest must be a JSON object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (obj.schema_version !== 1) {
+    throw new Error('manifest schema_version must be 1');
+  }
+  if (!Array.isArray(obj.items)) {
+    throw new Error('manifest items must be an array');
+  }
+
+  const metadata: BatchUpdateMetadata = { manifest_sha256: manifestSha256 };
+  if (typeof obj.series_id === 'string') metadata.series_id = obj.series_id;
+  if (typeof obj.config_snapshot_hash === 'string') {
+    metadata.config_snapshot_hash = obj.config_snapshot_hash;
+  }
+
+  return {
+    items: obj.items as BatchUpdateItem[],
+    metadata,
+  };
+}

--- a/src/batch/runner.ts
+++ b/src/batch/runner.ts
@@ -1,0 +1,240 @@
+import type {
+  BatchUpdateFailure,
+  BatchUpdateItem,
+  BatchUpdateMetadata,
+  BatchUpdateResult,
+  PlytixProduct,
+  PlytixResult,
+} from '../types.js';
+import {
+  DEFAULT_BATCH_CONCURRENCY,
+  DEFAULT_BATCH_REQUEST_DELAY_MS,
+  buildPatchBody,
+  detectDuplicateResolvedTargets,
+  finishedResult,
+  getBatchItemKey,
+  parsePlytixErrors,
+  rejectedResult,
+  runWithConcurrency,
+  validateBatchItems,
+} from './helpers.js';
+
+export interface ResolvedProductRef {
+  id: string;
+  sku?: string;
+}
+
+export interface BatchUpdateOperations {
+  resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>>;
+  updateProduct(
+    productId: string,
+    body: {
+      label?: string;
+      status?: string;
+      attributes?: Record<string, unknown>;
+    }
+  ): Promise<PlytixResult<PlytixProduct>>;
+}
+
+export interface ExecuteBatchUpdateOptions {
+  maxItems: number;
+  maxBytes?: number;
+  dryRun?: boolean;
+  metadata?: BatchUpdateMetadata;
+  concurrency?: number;
+  requestDelayMs?: number;
+}
+
+interface ReadyRow {
+  index: number;
+  item: BatchUpdateItem;
+  key: string;
+  productId: string;
+}
+
+export async function executeBatchUpdate(
+  ops: BatchUpdateOperations,
+  input: unknown,
+  options: ExecuteBatchUpdateOptions
+): Promise<BatchUpdateResult> {
+  const validation = validateBatchItems(input, {
+    maxItems: options.maxItems,
+    maxBytes: options.maxBytes,
+  });
+  const total = Array.isArray(input) ? input.length : 0;
+  if (validation.failures.length > 0) {
+    return rejectedResult(total, validation.failures, options.metadata);
+  }
+
+  const items = validation.items;
+  const skus = Array.from(new Set(items.map((item) => item.sku).filter(Boolean) as string[]));
+
+  let resolution = new Map<string, ResolvedProductRef[]>();
+  let resolutionError: unknown;
+  if (skus.length > 0) {
+    try {
+      resolution = await ops.resolveProductIdsBySku(skus);
+    } catch (error) {
+      resolutionError = error;
+    }
+  }
+
+  const failures: BatchUpdateFailure[] = [];
+  const readyRows: ReadyRow[] = [];
+
+  items.forEach((item, index) => {
+    const key = getBatchItemKey(item);
+    let productId = item.product_id;
+
+    if (item.sku) {
+      if (resolutionError) {
+        failures.push({
+          index,
+          key,
+          ...(productId ? { product_id: productId } : {}),
+          stage: 'resolve',
+          errors: parsePlytixErrors(resolutionError),
+        });
+        return;
+      }
+
+      const matches = resolution.get(item.sku) ?? [];
+      if (matches.length === 0) {
+        failures.push({
+          index,
+          key,
+          ...(productId ? { product_id: productId } : {}),
+          stage: 'resolve',
+          errors: [{ field: 'sku', msg: `SKU not found: ${item.sku}` }],
+        });
+        return;
+      }
+      if (matches.length > 1) {
+        failures.push({
+          index,
+          key,
+          ...(productId ? { product_id: productId } : {}),
+          stage: 'resolve',
+          errors: [{ field: 'sku', msg: `SKU resolved to multiple products: ${item.sku}` }],
+        });
+        return;
+      }
+
+      const resolvedId = matches[0].id;
+      if (productId && productId !== resolvedId) {
+        failures.push({
+          index,
+          key,
+          product_id: productId,
+          stage: 'verify',
+          errors: [
+            {
+              field: 'product_id',
+              msg: `SKU ${item.sku} resolves to ${resolvedId}, not ${productId}`,
+            },
+          ],
+        });
+        return;
+      }
+      productId = productId ?? resolvedId;
+    }
+
+    if (!productId) {
+      failures.push({
+        index,
+        key,
+        stage: 'resolve',
+        errors: [{ field: 'product_id', msg: 'product_id could not be resolved' }],
+      });
+      return;
+    }
+
+    readyRows.push({ index, item, key, productId });
+  });
+
+  const duplicateFailures = detectDuplicateResolvedTargets(readyRows);
+  if (duplicateFailures.length > 0) {
+    return rejectedResult(total, [...failures, ...duplicateFailures], options.metadata);
+  }
+
+  if (options.dryRun) {
+    return finishedResult({
+      total,
+      succeeded: 0,
+      failures,
+      skipped: total,
+      dryRun: true,
+      metadata: options.metadata,
+    });
+  }
+
+  const patchResults = await runWithConcurrency(
+    readyRows,
+    {
+      concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
+      requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
+    },
+    (row) => patchRowWithRetry(ops, row)
+  );
+
+  const patchFailures = patchResults.filter(Boolean) as BatchUpdateFailure[];
+  const allFailures = [...failures, ...patchFailures];
+
+  return finishedResult({
+    total,
+    succeeded: readyRows.length - patchFailures.length,
+    failures: allFailures,
+    skipped: failures.length,
+    metadata: options.metadata,
+  });
+}
+
+async function patchRowWithRetry(
+  ops: BatchUpdateOperations,
+  row: ReadyRow,
+  retries = 2
+): Promise<BatchUpdateFailure | undefined> {
+  const body = buildPatchBody(row.item);
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const result = await ops.updateProduct(row.productId, body);
+      const updated = result.data?.[0];
+      if (!updated?.id) {
+        return {
+          index: row.index,
+          key: row.key,
+          product_id: row.productId,
+          stage: 'patch',
+          errors: [{ msg: `Product update returned no confirmed product for ${row.productId}` }],
+        };
+      }
+      return undefined;
+    } catch (error) {
+      if (attempt < retries && isTransientError(error)) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * 2 ** attempt));
+        continue;
+      }
+      return {
+        index: row.index,
+        key: row.key,
+        product_id: row.productId,
+        stage: 'patch',
+        errors: parsePlytixErrors(error),
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function isTransientError(error: unknown): boolean {
+  const status =
+    error && typeof error === 'object' && 'status' in error
+      ? (error as { status?: unknown }).status
+      : undefined;
+  if (typeof status === 'number') {
+    return status === 429 || status >= 500;
+  }
+  return true;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -239,23 +239,31 @@ export class PlytixClient {
   async resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>> {
     const resolved = new Map<string, ResolvedProductRef[]>();
     const uniqueSkus = Array.from(new Set(skus.filter(Boolean)));
-    const chunkSize = 100;
+    const pageSize = 100;
 
-    for (let i = 0; i < uniqueSkus.length; i += chunkSize) {
-      const batch = uniqueSkus.slice(i, i + chunkSize);
-      const result = await this.searchProducts({
-        filters: [[{ field: 'sku', operator: 'in', value: batch }]],
-        attributes: ['sku'],
-        pagination: { page: 1, page_size: 100 },
-      });
+    for (let i = 0; i < uniqueSkus.length; i += pageSize) {
+      const batch = uniqueSkus.slice(i, i + pageSize);
+      let page = 1;
+      let totalPages = 1;
 
-      for (const product of result.data ?? []) {
-        if (!product.sku) continue;
-        resolved.set(product.sku, [
-          ...(resolved.get(product.sku) ?? []),
-          { id: product.id, sku: product.sku },
-        ]);
-      }
+      do {
+        const result = await this.searchProducts({
+          filters: [[{ field: 'sku', operator: 'in', value: batch }]],
+          attributes: ['sku'],
+          pagination: { page, page_size: pageSize },
+        });
+
+        for (const product of result.data ?? []) {
+          if (!product.sku) continue;
+          resolved.set(product.sku, [
+            ...(resolved.get(product.sku) ?? []),
+            { id: product.id, sku: product.sku },
+          ]);
+        }
+
+        totalPages = Math.max(result.pagination?.pages ?? 1, 1);
+        page += 1;
+      } while (page <= totalPages);
     }
 
     return resolved;

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,8 +25,19 @@ import type {
   PlytixAttributeDetail,
   PlytixRelationshipDefinition,
   RateLimitInfo,
+  BatchUpdateMetadata,
+  BatchUpdateResult,
 } from './types.js';
 import { PlytixError } from './types.js';
+import {
+  STDIO_INLINE_MAX_ITEMS,
+  type BatchValidationOptions,
+} from './batch/helpers.js';
+import {
+  executeBatchUpdate,
+  type ExecuteBatchUpdateOptions,
+  type ResolvedProductRef,
+} from './batch/runner.js';
 
 const DEFAULT_CONFIG = {
   baseUrl: 'https://pim.plytix.com',
@@ -222,6 +233,48 @@ export class PlytixClient {
     return this.request<PlytixProduct>('/api/v2/products/search', {
       method: 'POST',
       body: JSON.stringify(body),
+    });
+  }
+
+  async resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>> {
+    const resolved = new Map<string, ResolvedProductRef[]>();
+    const uniqueSkus = Array.from(new Set(skus.filter(Boolean)));
+    const chunkSize = 100;
+
+    for (let i = 0; i < uniqueSkus.length; i += chunkSize) {
+      const batch = uniqueSkus.slice(i, i + chunkSize);
+      const result = await this.searchProducts({
+        filters: [[{ field: 'sku', operator: 'in', value: batch }]],
+        attributes: ['sku'],
+        pagination: { page: 1, page_size: 100 },
+      });
+
+      for (const product of result.data ?? []) {
+        if (!product.sku) continue;
+        resolved.set(product.sku, [
+          ...(resolved.get(product.sku) ?? []),
+          { id: product.id, sku: product.sku },
+        ]);
+      }
+    }
+
+    return resolved;
+  }
+
+  async batchUpdateProducts(
+    items: unknown,
+    options: Partial<ExecuteBatchUpdateOptions> & {
+      metadata?: BatchUpdateMetadata;
+      maxItems?: BatchValidationOptions['maxItems'];
+    } = {}
+  ): Promise<BatchUpdateResult> {
+    return executeBatchUpdate(this, items, {
+      maxItems: options.maxItems ?? STDIO_INLINE_MAX_ITEMS,
+      maxBytes: options.maxBytes,
+      dryRun: options.dryRun,
+      metadata: options.metadata,
+      concurrency: options.concurrency,
+      requestDelayMs: options.requestDelayMs,
     });
   }
 

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -12,6 +12,20 @@ import type { PlytixProduct } from '../types.js';
 import { PlytixLookup } from '../lookup/index.js';
 import { registerTool } from './register.js';
 import type { IdentifierType } from '../lookup/identifier.js';
+import {
+  MANIFEST_MAX_ITEMS,
+  STDIO_INLINE_MAX_BYTES,
+  STDIO_INLINE_MAX_ITEMS,
+} from '../batch/helpers.js';
+import { readBatchManifest } from '../batch/manifest.js';
+
+const batchUpdateItemSchema = z.object({
+  sku: z.string().min(1).optional(),
+  product_id: z.string().min(1).optional(),
+  label: z.string().optional(),
+  status: z.string().optional(),
+  attributes: z.record(z.unknown()).optional(),
+});
 
 export function registerProductTools(server: McpServer, client: PlytixClient) {
   // Create lookup instance for smart search
@@ -551,6 +565,103 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
             {
               type: 'text',
               text: `Error updating product: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products.batch_update - Batch update products by product_id/sku
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{
+    items: unknown[];
+    dry_run?: boolean;
+  }>(
+    server,
+    'products_batch_update',
+    {
+      title: 'Batch Update Products',
+      description: 'Update a small batch of products by product_id or sku using documented product PATCH operations.',
+      inputSchema: {
+        items: z
+          .array(batchUpdateItemSchema)
+          .describe(`Products to update (max ${STDIO_INLINE_MAX_ITEMS} items and ${STDIO_INLINE_MAX_BYTES} serialized bytes)`),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe('Validate, resolve, and verify the batch without applying PATCH updates'),
+      },
+    },
+    async ({ items, dry_run }) => {
+      try {
+        const result = await client.batchUpdateProducts(items, {
+          dryRun: dry_run === true,
+          maxItems: STDIO_INLINE_MAX_ITEMS,
+          maxBytes: STDIO_INLINE_MAX_BYTES,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          ...(result.status === 'rejected' ? { isError: true } : {}),
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error running batch update: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products.batch_update_manifest - Stdio-only manifest batch update
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<{
+    manifest_path: string;
+    dry_run?: boolean;
+  }>(
+    server,
+    'products_batch_update_manifest',
+    {
+      title: 'Batch Update Products From Manifest',
+      description: 'Read a local JSON manifest and update products without sending large payloads through the model context.',
+      inputSchema: {
+        manifest_path: z.string().min(1).describe('Path to a schema_version: 1 JSON manifest'),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe('Validate, resolve, and verify the manifest without applying PATCH updates'),
+      },
+    },
+    async ({ manifest_path, dry_run }) => {
+      try {
+        const manifest = await readBatchManifest(manifest_path);
+        const result = await client.batchUpdateProducts(manifest.items, {
+          dryRun: dry_run === true,
+          maxItems: MANIFEST_MAX_ITEMS,
+          metadata: manifest.metadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          ...(result.status === 'rejected' ? { isError: true } : {}),
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error reading batch manifest: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
           isError: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,66 @@ export interface PlytixProduct {
   [key: string]: unknown;
 }
 
+// ─────────────────────────────────────────────────────────────
+// Batch Product Updates
+// ─────────────────────────────────────────────────────────────
+
+export interface BatchUpdateItem {
+  sku?: string;
+  product_id?: string;
+  label?: string;
+  status?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export type BatchUpdateFailureStage =
+  | 'validation'
+  | 'resolve'
+  | 'verify'
+  | 'duplicate'
+  | 'patch';
+
+export interface BatchUpdateErrorDetail {
+  field?: string;
+  msg: string;
+}
+
+export interface BatchUpdateFailure {
+  key: string;
+  index: number;
+  product_id?: string;
+  stage: BatchUpdateFailureStage;
+  errors: BatchUpdateErrorDetail[];
+}
+
+export interface BatchUpdateSummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface BatchUpdateMetadata {
+  series_id?: string;
+  config_snapshot_hash?: string;
+  manifest_sha256?: string;
+}
+
+export type BatchUpdateResult =
+  | {
+      status: 'rejected';
+      summary: BatchUpdateSummary;
+      failures: BatchUpdateFailure[];
+      metadata?: BatchUpdateMetadata;
+    }
+  | {
+      status: 'finished';
+      dry_run?: boolean;
+      summary: BatchUpdateSummary;
+      failures: BatchUpdateFailure[];
+      metadata?: BatchUpdateMetadata;
+    };
+
 export interface PlytixRelationship {
   relationship_id: string;
   relationship_label: string;

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -24,8 +24,19 @@ import type {
   PlytixFilterDefinition,
   PlytixRelationshipDefinition,
   RateLimitInfo,
+  BatchUpdateMetadata,
+  BatchUpdateResult,
 } from './types.js';
 import { PlytixError } from './types.js';
+import {
+  WORKER_INLINE_MAX_ITEMS,
+  type BatchValidationOptions,
+} from './batch/helpers.js';
+import {
+  executeBatchUpdate,
+  type ExecuteBatchUpdateOptions,
+  type ResolvedProductRef,
+} from './batch/runner.js';
 
 const DEFAULT_CONFIG = {
   baseUrl: 'https://pim.plytix.com',
@@ -291,6 +302,48 @@ export class WorkerPlytixClient {
     return this.request<PlytixProduct>('/api/v2/products/search', {
       method: 'POST',
       body: JSON.stringify(body),
+    });
+  }
+
+  async resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>> {
+    const resolved = new Map<string, ResolvedProductRef[]>();
+    const uniqueSkus = Array.from(new Set(skus.filter(Boolean)));
+    const chunkSize = 100;
+
+    for (let i = 0; i < uniqueSkus.length; i += chunkSize) {
+      const batch = uniqueSkus.slice(i, i + chunkSize);
+      const result = await this.searchProducts({
+        filters: [[{ field: 'sku', operator: 'in', value: batch }]],
+        attributes: ['sku'],
+        pagination: { page: 1, page_size: 100 },
+      });
+
+      for (const product of result.data ?? []) {
+        if (!product.sku) continue;
+        resolved.set(product.sku, [
+          ...(resolved.get(product.sku) ?? []),
+          { id: product.id, sku: product.sku },
+        ]);
+      }
+    }
+
+    return resolved;
+  }
+
+  async batchUpdateProducts(
+    items: unknown,
+    options: Partial<ExecuteBatchUpdateOptions> & {
+      metadata?: BatchUpdateMetadata;
+      maxItems?: BatchValidationOptions['maxItems'];
+    } = {}
+  ): Promise<BatchUpdateResult> {
+    return executeBatchUpdate(this, items, {
+      maxItems: options.maxItems ?? WORKER_INLINE_MAX_ITEMS,
+      maxBytes: options.maxBytes,
+      dryRun: options.dryRun,
+      metadata: options.metadata,
+      concurrency: options.concurrency,
+      requestDelayMs: options.requestDelayMs,
     });
   }
 

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -308,23 +308,31 @@ export class WorkerPlytixClient {
   async resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>> {
     const resolved = new Map<string, ResolvedProductRef[]>();
     const uniqueSkus = Array.from(new Set(skus.filter(Boolean)));
-    const chunkSize = 100;
+    const pageSize = 100;
 
-    for (let i = 0; i < uniqueSkus.length; i += chunkSize) {
-      const batch = uniqueSkus.slice(i, i + chunkSize);
-      const result = await this.searchProducts({
-        filters: [[{ field: 'sku', operator: 'in', value: batch }]],
-        attributes: ['sku'],
-        pagination: { page: 1, page_size: 100 },
-      });
+    for (let i = 0; i < uniqueSkus.length; i += pageSize) {
+      const batch = uniqueSkus.slice(i, i + pageSize);
+      let page = 1;
+      let totalPages = 1;
 
-      for (const product of result.data ?? []) {
-        if (!product.sku) continue;
-        resolved.set(product.sku, [
-          ...(resolved.get(product.sku) ?? []),
-          { id: product.id, sku: product.sku },
-        ]);
-      }
+      do {
+        const result = await this.searchProducts({
+          filters: [[{ field: 'sku', operator: 'in', value: batch }]],
+          attributes: ['sku'],
+          pagination: { page, page_size: pageSize },
+        });
+
+        for (const product of result.data ?? []) {
+          if (!product.sku) continue;
+          resolved.set(product.sku, [
+            ...(resolved.get(product.sku) ?? []),
+            { id: product.id, sku: product.sku },
+          ]);
+        }
+
+        totalPages = Math.max(result.pagination?.pages ?? 1, 1);
+        page += 1;
+      } while (page <= totalPages);
     }
 
     return resolved;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,6 +14,7 @@ import { WorkerPlytixClient } from './worker-client.js';
 import { WorkerPlytixLookup } from './worker-lookup.js';
 import { stripAttributesPrefix } from './utils/attribute-labels.js';
 import { validateAttributeValue } from './utils/validate-attribute.js';
+import { WORKER_INLINE_MAX_BYTES, WORKER_INLINE_MAX_ITEMS } from './batch/helpers.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -615,6 +616,37 @@ const TOOLS: ToolDefinition[] = [
         },
       },
       required: ['product_id'],
+    },
+  },
+  {
+    name: 'products_batch_update',
+    description: 'Update a small batch of products by product_id or sku using documented product PATCH operations.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          description: `Products to update (max ${WORKER_INLINE_MAX_ITEMS} items and ${WORKER_INLINE_MAX_BYTES} serialized bytes)`,
+          items: {
+            type: 'object',
+            properties: {
+              sku: { type: 'string', description: 'Product SKU for reporting and resolution' },
+              product_id: { type: 'string', description: 'Product ID to PATCH when known' },
+              label: { type: 'string', description: 'New product label/name' },
+              status: { type: 'string', description: 'New product status' },
+              attributes: {
+                type: 'object',
+                description: 'Attributes to update (use attribute labels as keys, null to clear)',
+              },
+            },
+          },
+        },
+        dry_run: {
+          type: 'boolean',
+          description: 'Validate, resolve, and verify the batch without applying PATCH updates',
+        },
+      },
+      required: ['items'],
     },
   },
   {
@@ -1685,6 +1717,19 @@ const toolHandlers: Record<string, ToolHandler> = {
           ),
         },
       ],
+    };
+  },
+
+  async products_batch_update(args, client) {
+    const result = await client.batchUpdateProducts(args.items, {
+      dryRun: args.dry_run === true,
+      maxItems: WORKER_INLINE_MAX_ITEMS,
+      maxBytes: WORKER_INLINE_MAX_BYTES,
+    });
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      ...(result.status === 'rejected' ? { isError: true } : {}),
     };
   },
 


### PR DESCRIPTION
## Summary
**Batch product updates**
- Adds `products_batch_update` for stdio and Worker inline batches over documented product PATCH.
- Adds stdio-only `products_batch_update_manifest` for local `schema_version: 1` JSON manifests, with SHA-256 metadata and a 10,000 item cap.
- Adds shared validation/execution helpers: item schema, byte caps, SKU resolution, `sku`/`product_id` verification, duplicate checks, `dry_run`, paced concurrency, transient retry, and structured failures.
- Extends stdio and Worker clients with SKU resolution and batch update methods.

**Docs and release**
- Adds batch-update spec/plan/REST evidence documenting `use_patch_loop` until first-party async endpoint evidence exists.
- Updates Worker parity docs and CLAUDE tool list.
- Releases package `0.3.0`.

## Test Coverage
- Added `src/__tests__/batch-update.test.ts` with 11 tests.
- Coverage audit: new batch code paths covered for structural validation, byte caps, dry-run, SKU/product_id mismatch, duplicate targets before PATCH, mixed resolve/PATCH failures, structured Plytix errors, manifest schema/hash parsing, and Worker tool surface.
- Remaining live-only path: actual Plytix smoke update should be run with credentials on 2-4 products before a production manifest backfill.

Tests: existing 4 files -> 5 files (+1); 54 tests passing.

## Pre-Landing Review
No issues found. Manual review focused on:
- no manifest payload echoing in errors,
- no private UI/import endpoint dependency,
- Worker lower inline cap and stdio-only manifest boundary,
- token refresh and 429/5xx retry behavior.

## Design Review
No frontend files changed - design review skipped.

## Eval Results
No prompt-related files changed - evals skipped.

## Scope Drift
Scope Check: CLEAN
Intent: ship batch product update tools for agent-safe product backfills without threading large payloads through model context.
Delivered: PATCH-loop batch tools, manifest submit path, dry_run, guards, docs, tests, and release metadata.

## Plan Completion
Plan file: `docs/features/batch-update/PLAN.md`

- DONE: Step 0 REST evidence recorded with conclusion `use_patch_loop`.
- DONE: Shared batch types/helpers/result shape.
- DONE: Client and Worker execution paths with SKU resolution, verification, pacing, retries, and token-refresh support via existing request layer.
- DONE: Stdio inline + manifest tools; Worker inline-only tool with lower caps.
- DONE: Unit tests and docs updates.
- MANUAL: live 2-4 product smoke with real Plytix credentials before production backfill. Not run during ship to avoid live mutations.

## Verification Results
- `npm test`: 5 files, 54 tests passed.
- `npm run typecheck`: passed.
- `npm run typecheck:worker`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.

## TODOS
No `TODOS.md` exists in this repo, so no TODO items were updated.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run typecheck:worker`
- [x] `npm run build`
- [x] `git diff --check`

Generated with Codex.