### PR TITLE
v0.3.1 feat: add batch update drift guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-09
+
+### Added
+- Added per-item optimistic-concurrency guards for batch updates via
+  `expected_attributes` and `if_match`, returning `stage: "conflict"` when live data
+  drifts before PATCH.
+- Added opt-in batch-update success rows with `return_successes` for exact caller ledgers.
+
+### Fixed
+- Guarded batch rows now read live product data immediately before PATCH and skip drifted
+  rows instead of applying stale read-modify-write updates.
+
 ## [0.3.0] - 2026-06-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ src/
 |------|-------------|
 | `products_create` | Create a new product (SKU required) |
 | `products_update` | Update product fields and attributes (PATCH) |
-| `products_batch_update` | Update a small batch of products by `product_id` or `sku` (PATCH loop; inline capped) |
-| `products_batch_update_manifest` | Update products from a local JSON manifest (stdio-only; supports dry run) |
+| `products_batch_update` | Update a small batch of products by `product_id` or `sku` (PATCH loop; inline capped; supports drift guards) |
+| `products_batch_update_manifest` | Update products from a local JSON manifest (stdio-only; supports dry run and drift guards) |
 | `products_assign_family` | Assign or unassign family (may cause data loss) |
 | `products_set_attribute` | Set one product attribute atomically |
 | `products_clear_attribute` | Clear one product attribute atomically |

--- a/docs/features/batch-update/PLAN.md
+++ b/docs/features/batch-update/PLAN.md
@@ -15,6 +15,9 @@
 - Verify `sku` and `product_id` point to the same product before PATCH when both are
   present.
 - Add `dry_run` to both tools.
+- Add per-item optimistic guards with `expected_attributes` / `if_match`, reported as
+  `stage: "conflict"` with no PATCH when live data drifts.
+- Add opt-in per-item success rows with `return_successes` for exact caller ledgers.
 - Keep the 10,000 item cap for manifest runs. Stdio inline runs cap at 250 items and
   512 KB serialized payload; Worker inline runs cap at 50 items and 256 KB.
 - Long runs must tolerate token expiry, rate pacing, and retryable upstream failures.
@@ -69,6 +72,7 @@
    - resolve missing product IDs,
    - verify all `sku + product_id` pairs by resolving SKU and comparing IDs,
    - reject post-resolution duplicate product IDs,
+   - read guarded products immediately before PATCH and skip drifted rows as conflicts,
    - PATCH with bounded concurrency and pacing,
    - refresh auth on expiry/401 during long runs,
    - retry transient 5xx/timeouts before recording row failure,
@@ -78,8 +82,8 @@
 ## Step 3 - Tool Surfaces
 
 1. In `src/tools/products.ts`, register:
-   - `products_batch_update({ items, dry_run? })`
-   - `products_batch_update_manifest({ manifest_path, dry_run? })`
+   - `products_batch_update({ items, dry_run?, return_successes? })`
+   - `products_batch_update_manifest({ manifest_path, dry_run?, return_successes? })`
 2. Manifest tool behavior:
    - read UTF-8 JSON from disk,
    - require a `.json` path and `schema_version: 1`,

--- a/docs/features/batch-update/SPEC.md
+++ b/docs/features/batch-update/SPEC.md
@@ -55,6 +55,8 @@ interface BatchUpdateItem {
   label?: string;
   status?: string;
   attributes?: Record<string, unknown>; // null clears an attribute
+  expected_attributes?: Record<string, unknown>; // attribute drift guard
+  if_match?: Record<string, unknown>; // field-path drift guard, e.g. status or attributes.foo
 }
 ```
 
@@ -66,6 +68,7 @@ Validation before any write:
 - At least one of `label`, `status`, or non-empty `attributes` is required.
 - `attributes` must be a plain object when present.
 - `attributes: {}` is invalid unless `label` or `status` is present.
+- `expected_attributes` and `if_match` must be non-empty plain objects when present.
 - `null` values inside `attributes` are allowed because they clear attributes.
 - `sku` itself is not patchable in v1.
 - Attribute format/value validation is out of scope; Plytix rejects are surfaced per row.
@@ -75,6 +78,10 @@ Validation before any write:
 - When both `sku` and `product_id` are present, resolve the SKU and verify it maps to the
   same product before PATCH. Mismatches become row failures with `stage: "verify"` and
   that row is skipped.
+- When `expected_attributes` or `if_match` is present, read the live product immediately
+  before PATCH. If any expected value differs, skip the row with `stage: "conflict"`.
+  `expected_attributes` compares keys inside `product.attributes`; `if_match` compares
+  top-level fields or `attributes.<label>` paths.
 
 If any item is structurally invalid, reject the whole call and return the offending
 indices. Do not partially apply a structurally invalid batch.
@@ -134,7 +141,8 @@ filesystem. This is an intentional stdio-only exception to worker parity.
 ```ts
 {
   items: BatchUpdateItem[],
-  dry_run?: boolean
+  dry_run?: boolean,
+  return_successes?: boolean
 }
 ```
 
@@ -145,8 +153,11 @@ Rules:
 - Worker inline cap: **50 items** and **256 KB** serialized payload.
 - Large or text-heavy updates should use the stdio manifest tool even when under the item
   cap.
+- `return_successes: true` includes one success row per patched product for exact caller
+  ledger updates. It defaults off to keep large responses compact.
 
-`products_batch_update_manifest` also accepts `dry_run?: boolean`.
+`products_batch_update_manifest` also accepts `dry_run?: boolean` and
+`return_successes?: boolean`.
 
 Dry run:
 
@@ -154,6 +165,7 @@ Dry run:
 - computes `manifest_sha256` when applicable,
 - resolves SKUs,
 - verifies `sku`/`product_id` pairs,
+- checks `expected_attributes` and `if_match` against current live product data,
 - detects duplicate targets,
 - returns the same result shape with `dry_run: true`,
 - performs zero PATCH calls.
@@ -167,11 +179,13 @@ Primary v1 implementation uses documented product APIs from
 2. Resolve missing `product_id` values by exact SKU search:
    `POST /api/v2/products/search`, with no `pagination.order`, `page_size <= 100`,
    and paging through each chunk until `pagination.pages` is exhausted.
-3. PATCH each product with bounded concurrency:
+3. For rows with `expected_attributes` or `if_match`, read the live product and compare
+   expected values immediately before PATCH. Drift is returned as `stage: "conflict"`.
+4. PATCH each product with bounded concurrency:
    `PATCH /api/v2/products/:product_id`.
-4. Reuse existing auth, timeout, 401 retry, and 429 backoff in `client.ts` and
+5. Reuse existing auth, timeout, 401 retry, and 429 backoff in `client.ts` and
    `worker-client.ts`.
-5. Return per-key success/failure results.
+6. Return per-key success/failure results.
 
 Step 0 remains first, but it is an acceleration probe, not a build gate:
 
@@ -214,8 +228,14 @@ Completed run:
     index: number,
     key: string,
     product_id?: string,
-    stage: "resolve" | "verify" | "patch",
+    stage: "resolve" | "verify" | "conflict" | "patch",
     errors: Array<{ field?: string, msg: string }>
+  }>,
+  successes?: Array<{
+    index: number,
+    key: string,
+    product_id: string,
+    modified?: string
   }>,
   metadata?: BatchMetadata
 }
@@ -240,6 +260,8 @@ Result rules:
 - Validation or duplicate batch-level errors return `status: "rejected"` with no API
   mutations.
 - Unresolved SKU or `sku`/`product_id` mismatch is a row failure and skipped PATCH.
+- `expected_attributes` or `if_match` mismatches are row failures with
+  `stage: "conflict"` and skipped PATCH.
 - PATCH failure is a row failure.
 - Success only means the PATCH request succeeded for that row.
 
@@ -248,6 +270,7 @@ Result rules:
 - Structural validation errors reject the whole call before any API request.
 - SKU resolution failures are row failures with `stage: "resolve"`.
 - SKU/product ID mismatches are row failures with `stage: "verify"`.
+- Optimistic-concurrency guard mismatches are row failures with `stage: "conflict"`.
 - Plytix PATCH rejects are row failures with `stage: "patch"` and the Plytix
   `{ field, msg }` details when available.
 - Unexpected or unparsable Plytix errors still include a clear message and the row key.
@@ -284,8 +307,11 @@ Unit tests with no live API:
 - `product_id` + `sku` together is valid and reports by `sku`.
 - SKU resolution and verification: found, not found, duplicate SKU result, mismatch
   between `sku` and `product_id`, and fallback/error mapping.
+- Optimistic-concurrency guards: matching live values, drifted live values, and no PATCH
+  after a guard conflict.
 - PATCH aggregation: mixed successes/failures, preserved indices, correct
   `succeeded`/`failed`/`skipped` counts.
+- Optional success rows: `return_successes` reports exact patched keys/product IDs.
 - Error parsing: Plytix `{ error: { errors: [...] } }`, top-level messages, and unknown
   errors.
 - Manifest read: valid file, missing file, non-JSON path, oversized file, malformed JSON,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plytix-mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "MCP server for Plytix PIM API integration. Enables AI assistants to read, write, and manage product data, assets, categories, and relationships.",
   "keywords": [

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -284,6 +284,52 @@ describe('executeBatchUpdate', () => {
     expect(ops.updateProduct).not.toHaveBeenCalled();
   });
 
+  it('checks each guarded row immediately before its own PATCH', async () => {
+    const events: string[] = [];
+    const ops = makeOps({
+      get: async (productId) => {
+        events.push(`get:${productId}`);
+        return {
+          data: [
+            {
+              id: productId,
+              attributes: { google_detail: `${productId}:old` },
+            },
+          ],
+        };
+      },
+      update: async (productId) => {
+        events.push(`patch:${productId}`);
+        return productResult(productId);
+      },
+    });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [
+        {
+          product_id: 'product-1',
+          attributes: { google_detail: 'one:new' },
+          expected_attributes: { google_detail: 'product-1:old' },
+        },
+        {
+          product_id: 'product-2',
+          attributes: { google_detail: 'two:new' },
+          expected_attributes: { google_detail: 'product-2:old' },
+        },
+      ],
+      { maxItems: 250, concurrency: 1, requestDelayMs: 0 }
+    );
+
+    expect(result.summary).toEqual({ total: 2, succeeded: 2, failed: 0, skipped: 0 });
+    expect(events).toEqual([
+      'get:product-1',
+      'patch:product-1',
+      'get:product-2',
+      'patch:product-2',
+    ]);
+  });
+
   it('returns exact success rows when requested', async () => {
     const ops = makeOps();
 

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -44,12 +44,23 @@ const skuResolutionPage = (page: number): PlytixResult<PlytixProduct> => {
 
 function makeOps(args?: {
   resolved?: Record<string, Array<{ id: string; sku?: string }>>;
+  live?: Record<string, PlytixProduct | undefined>;
+  get?: (productId: string) => Promise<PlytixResult<PlytixProduct>>;
   update?: (productId: string) => Promise<PlytixResult<PlytixProduct>>;
 }): BatchUpdateOperations & {
+  getProduct: ReturnType<typeof vi.fn>;
   resolveProductIdsBySku: ReturnType<typeof vi.fn>;
   updateProduct: ReturnType<typeof vi.fn>;
 } {
   return {
+    getProduct: vi.fn(async (productId: string) => {
+      if (args?.get) return args.get(productId);
+      const product = args?.live?.[productId] ?? {
+        id: productId,
+        modified: '2026-06-09T00:00:00Z',
+      };
+      return { data: product ? [product] : [] };
+    }),
     resolveProductIdsBySku: vi.fn(async (skus: string[]) => {
       const map = new Map<string, Array<{ id: string; sku?: string }>>();
       for (const sku of skus) {
@@ -116,6 +127,21 @@ describe('batch update validation', () => {
     );
 
     expect(result.failures[0]?.errors[0]?.msg).toContain('inline payload');
+  });
+
+  it('rejects empty or non-object optimistic guards', () => {
+    const result = validateBatchItems(
+      [
+        { product_id: '1', label: 'one', expected_attributes: {} },
+        { product_id: '2', label: 'two', if_match: [] },
+      ],
+      { maxItems: 250 }
+    );
+
+    expect(result.failures.map((failure) => failure.errors[0]?.field)).toEqual([
+      'expected_attributes',
+      'if_match',
+    ]);
   });
 });
 
@@ -212,6 +238,72 @@ describe('executeBatchUpdate', () => {
       field: 'attributes.google_detail',
       msg: 'too long',
     });
+  });
+
+  it('skips guarded rows whose live values drift before PATCH', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: {
+        'product-1': {
+          id: 'product-1',
+          sku: 'GUARDED',
+          status: 'ACTIVE',
+          attributes: { google_detail: 'changed' },
+        },
+      },
+    });
+
+    const result = await executeBatchUpdate(
+      ops,
+      [
+        {
+          sku: 'GUARDED',
+          attributes: { google_detail: 'new value' },
+          expected_attributes: { google_detail: 'original' },
+          if_match: { status: 'ACTIVE' },
+        },
+      ],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toEqual({ total: 1, succeeded: 0, failed: 1, skipped: 1 });
+    expect(result.failures[0]).toMatchObject({
+      index: 0,
+      key: 'GUARDED',
+      product_id: 'product-1',
+      stage: 'conflict',
+    });
+    expect(result.failures[0]?.errors).toEqual([
+      {
+        field: 'expected_attributes.google_detail',
+        msg: 'live attribute no longer matches expected value',
+      },
+    ]);
+    expect(ops.getProduct).toHaveBeenCalledWith('product-1');
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('returns exact success rows when requested', async () => {
+    const ops = makeOps();
+
+    const result = await executeBatchUpdate(
+      ops,
+      [{ product_id: 'product-1', label: 'New label' }],
+      { maxItems: 250, returnSuccesses: true, requestDelayMs: 0 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
+    expect(result.successes).toEqual([
+      {
+        index: 0,
+        key: 'product-1',
+        product_id: 'product-1',
+        modified: '2026-06-09T00:00:00Z',
+      },
+    ]);
+    expect(ops.getProduct).not.toHaveBeenCalled();
   });
 });
 

--- a/src/batch/helpers.ts
+++ b/src/batch/helpers.ts
@@ -4,6 +4,7 @@ import type {
   BatchUpdateItem,
   BatchUpdateMetadata,
   BatchUpdateResult,
+  BatchUpdateSuccess,
 } from '../types.js';
 
 export const STDIO_INLINE_MAX_ITEMS = 250;
@@ -171,6 +172,46 @@ export function validateBatchItems(
       }
     }
 
+    if (item.expected_attributes !== undefined) {
+      if (!isPlainObject(item.expected_attributes)) {
+        failures.push(
+          makeFailure(
+            index,
+            item,
+            'validation',
+            'expected_attributes must be an object',
+            'expected_attributes'
+          )
+        );
+      } else if (Object.keys(item.expected_attributes).length === 0) {
+        failures.push(
+          makeFailure(
+            index,
+            item,
+            'validation',
+            'expected_attributes must not be empty',
+            'expected_attributes'
+          )
+        );
+      } else {
+        normalized.expected_attributes = item.expected_attributes;
+      }
+    }
+
+    if (item.if_match !== undefined) {
+      if (!isPlainObject(item.if_match)) {
+        failures.push(
+          makeFailure(index, item, 'validation', 'if_match must be an object', 'if_match')
+        );
+      } else if (Object.keys(item.if_match).length === 0) {
+        failures.push(
+          makeFailure(index, item, 'validation', 'if_match must not be empty', 'if_match')
+        );
+      } else {
+        normalized.if_match = item.if_match;
+      }
+    }
+
     const hasAttributes =
       normalized.attributes !== undefined && Object.keys(normalized.attributes).length > 0;
     if (
@@ -328,6 +369,7 @@ export function finishedResult(args: {
   failures: BatchUpdateFailure[];
   skipped: number;
   dryRun?: boolean;
+  successes?: BatchUpdateSuccess[];
   metadata?: BatchUpdateMetadata;
 }): BatchUpdateResult {
   return {
@@ -340,6 +382,7 @@ export function finishedResult(args: {
       skipped: args.skipped,
     },
     failures: args.failures,
+    ...(args.successes ? { successes: args.successes } : {}),
     ...(args.metadata ? { metadata: args.metadata } : {}),
   };
 }

--- a/src/batch/runner.ts
+++ b/src/batch/runner.ts
@@ -3,6 +3,7 @@ import type {
   BatchUpdateItem,
   BatchUpdateMetadata,
   BatchUpdateResult,
+  BatchUpdateSuccess,
   PlytixProduct,
   PlytixResult,
 } from '../types.js';
@@ -25,6 +26,7 @@ export interface ResolvedProductRef {
 }
 
 export interface BatchUpdateOperations {
+  getProduct(productId: string): Promise<PlytixResult<PlytixProduct>>;
   resolveProductIdsBySku(skus: string[]): Promise<Map<string, ResolvedProductRef[]>>;
   updateProduct(
     productId: string,
@@ -43,6 +45,7 @@ export interface ExecuteBatchUpdateOptions {
   metadata?: BatchUpdateMetadata;
   concurrency?: number;
   requestDelayMs?: number;
+  returnSuccesses?: boolean;
 }
 
 interface ReadyRow {
@@ -157,11 +160,28 @@ export async function executeBatchUpdate(
     return rejectedResult(total, [...failures, ...duplicateFailures], options.metadata);
   }
 
+  const guardRows = readyRows.filter((row) => row.item.expected_attributes || row.item.if_match);
+  const guardResults =
+    guardRows.length > 0
+      ? await runWithConcurrency(
+          guardRows,
+          {
+            concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
+            requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
+          },
+          (row) => checkRowGuard(ops, row)
+        )
+      : [];
+  const guardFailures = guardResults.filter(Boolean) as BatchUpdateFailure[];
+  const conflictedIndices = new Set(guardFailures.map((failure) => failure.index));
+  const patchRows = readyRows.filter((row) => !conflictedIndices.has(row.index));
+  const prePatchFailures = [...failures, ...guardFailures];
+
   if (options.dryRun) {
     return finishedResult({
       total,
       succeeded: 0,
-      failures,
+      failures: prePatchFailures,
       skipped: total,
       dryRun: true,
       metadata: options.metadata,
@@ -169,7 +189,7 @@ export async function executeBatchUpdate(
   }
 
   const patchResults = await runWithConcurrency(
-    readyRows,
+    patchRows,
     {
       concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
       requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
@@ -177,23 +197,142 @@ export async function executeBatchUpdate(
     (row) => patchRowWithRetry(ops, row)
   );
 
-  const patchFailures = patchResults.filter(Boolean) as BatchUpdateFailure[];
-  const allFailures = [...failures, ...patchFailures];
+  const patchFailures = patchResults
+    .filter((result): result is { status: 'failure'; failure: BatchUpdateFailure } =>
+      result?.status === 'failure'
+    )
+    .map((result) => result.failure);
+  const successes = patchResults
+    .filter((result): result is { status: 'success'; success: BatchUpdateSuccess } =>
+      result?.status === 'success'
+    )
+    .map((result) => result.success);
+  const allFailures = [...prePatchFailures, ...patchFailures];
 
   return finishedResult({
     total,
-    succeeded: readyRows.length - patchFailures.length,
+    succeeded: patchRows.length - patchFailures.length,
     failures: allFailures,
-    skipped: failures.length,
+    skipped: prePatchFailures.length,
+    ...(options.returnSuccesses ? { successes } : {}),
     metadata: options.metadata,
   });
 }
+
+async function checkRowGuard(
+  ops: BatchUpdateOperations,
+  row: ReadyRow
+): Promise<BatchUpdateFailure | undefined> {
+  if (!row.item.expected_attributes && !row.item.if_match) {
+    return undefined;
+  }
+
+  let product: PlytixProduct | undefined;
+  try {
+    const result = await ops.getProduct(row.productId);
+    product = result.data?.[0];
+  } catch (error) {
+    return {
+      index: row.index,
+      key: row.key,
+      product_id: row.productId,
+      stage: 'conflict',
+      errors: parsePlytixErrors(error),
+    };
+  }
+
+  if (!product?.id) {
+    return {
+      index: row.index,
+      key: row.key,
+      product_id: row.productId,
+      stage: 'conflict',
+      errors: [{ msg: `Product guard check returned no product for ${row.productId}` }],
+    };
+  }
+
+  const errors = [
+    ...compareExpectedAttributes(product, row.item.expected_attributes),
+    ...compareIfMatch(product, row.item.if_match),
+  ];
+  if (errors.length === 0) return undefined;
+
+  return {
+    index: row.index,
+    key: row.key,
+    product_id: row.productId,
+    stage: 'conflict',
+    errors,
+  };
+}
+
+function compareExpectedAttributes(
+  product: PlytixProduct,
+  expected?: Record<string, unknown>
+): Array<{ field?: string; msg: string }> {
+  if (!expected) return [];
+
+  return Object.entries(expected)
+    .filter(([field, value]) => !valuesEqual(product.attributes?.[field], value))
+    .map(([field]) => ({
+      field: `expected_attributes.${field}`,
+      msg: 'live attribute no longer matches expected value',
+    }));
+}
+
+function compareIfMatch(
+  product: PlytixProduct,
+  expected?: Record<string, unknown>
+): Array<{ field?: string; msg: string }> {
+  if (!expected) return [];
+
+  return Object.entries(expected)
+    .filter(([field, value]) => !valuesEqual(readProductPath(product, field), value))
+    .map(([field]) => ({
+      field: `if_match.${field}`,
+      msg: 'live field no longer matches expected value',
+    }));
+}
+
+function readProductPath(product: PlytixProduct, path: string): unknown {
+  if (path.startsWith('attributes.')) {
+    return product.attributes?.[path.slice('attributes.'.length)];
+  }
+  return product[path];
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => valuesEqual(value, right[index]))
+    );
+  }
+  if (isComparableObject(left) && isComparableObject(right)) {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every((key, index) => key === rightKeys[index] && valuesEqual(left[key], right[key]))
+    );
+  }
+  return false;
+}
+
+function isComparableObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+type PatchRowResult =
+  | { status: 'success'; success: BatchUpdateSuccess }
+  | { status: 'failure'; failure: BatchUpdateFailure };
 
 async function patchRowWithRetry(
   ops: BatchUpdateOperations,
   row: ReadyRow,
   retries = 2
-): Promise<BatchUpdateFailure | undefined> {
+): Promise<PatchRowResult> {
   const body = buildPatchBody(row.item);
 
   for (let attempt = 0; attempt <= retries; attempt++) {
@@ -202,30 +341,53 @@ async function patchRowWithRetry(
       const updated = result.data?.[0];
       if (!updated?.id) {
         return {
-          index: row.index,
-          key: row.key,
-          product_id: row.productId,
-          stage: 'patch',
-          errors: [{ msg: `Product update returned no confirmed product for ${row.productId}` }],
+          status: 'failure',
+          failure: {
+            index: row.index,
+            key: row.key,
+            product_id: row.productId,
+            stage: 'patch',
+            errors: [{ msg: `Product update returned no confirmed product for ${row.productId}` }],
+          },
         };
       }
-      return undefined;
+      return {
+        status: 'success',
+        success: {
+          index: row.index,
+          key: row.key,
+          product_id: updated.id,
+          ...(typeof updated.modified === 'string' ? { modified: updated.modified } : {}),
+        },
+      };
     } catch (error) {
       if (attempt < retries && isTransientError(error)) {
         await new Promise((resolve) => setTimeout(resolve, 500 * 2 ** attempt));
         continue;
       }
       return {
-        index: row.index,
-        key: row.key,
-        product_id: row.productId,
-        stage: 'patch',
-        errors: parsePlytixErrors(error),
+        status: 'failure',
+        failure: {
+          index: row.index,
+          key: row.key,
+          product_id: row.productId,
+          stage: 'patch',
+          errors: parsePlytixErrors(error),
+        },
       };
     }
   }
 
-  return undefined;
+  return {
+    status: 'failure',
+    failure: {
+      index: row.index,
+      key: row.key,
+      product_id: row.productId,
+      stage: 'patch',
+      errors: [{ msg: 'Product update retry loop exited unexpectedly' }],
+    },
+  };
 }
 
 function isTransientError(error: unknown): boolean {

--- a/src/batch/runner.ts
+++ b/src/batch/runner.ts
@@ -160,28 +160,25 @@ export async function executeBatchUpdate(
     return rejectedResult(total, [...failures, ...duplicateFailures], options.metadata);
   }
 
-  const guardRows = readyRows.filter((row) => row.item.expected_attributes || row.item.if_match);
-  const guardResults =
-    guardRows.length > 0
-      ? await runWithConcurrency(
-          guardRows,
-          {
-            concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
-            requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
-          },
-          (row) => checkRowGuard(ops, row)
-        )
-      : [];
-  const guardFailures = guardResults.filter(Boolean) as BatchUpdateFailure[];
-  const conflictedIndices = new Set(guardFailures.map((failure) => failure.index));
-  const patchRows = readyRows.filter((row) => !conflictedIndices.has(row.index));
-  const prePatchFailures = [...failures, ...guardFailures];
-
   if (options.dryRun) {
+    const guardRows = readyRows.filter((row) => row.item.expected_attributes || row.item.if_match);
+    const guardResults =
+      guardRows.length > 0
+        ? await runWithConcurrency(
+            guardRows,
+            {
+              concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
+              requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
+            },
+            (row) => checkRowGuard(ops, row)
+          )
+        : [];
+    const guardFailures = guardResults.filter(Boolean) as BatchUpdateFailure[];
+
     return finishedResult({
       total,
       succeeded: 0,
-      failures: prePatchFailures,
+      failures: [...failures, ...guardFailures],
       skipped: total,
       dryRun: true,
       metadata: options.metadata,
@@ -189,7 +186,7 @@ export async function executeBatchUpdate(
   }
 
   const patchResults = await runWithConcurrency(
-    patchRows,
+    readyRows,
     {
       concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
       requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
@@ -207,13 +204,14 @@ export async function executeBatchUpdate(
       result?.status === 'success'
     )
     .map((result) => result.success);
-  const allFailures = [...prePatchFailures, ...patchFailures];
+  const allFailures = [...failures, ...patchFailures];
+  const conflictFailures = patchFailures.filter((failure) => failure.stage === 'conflict');
 
   return finishedResult({
     total,
-    succeeded: patchRows.length - patchFailures.length,
+    succeeded: readyRows.length - patchFailures.length,
     failures: allFailures,
-    skipped: prePatchFailures.length,
+    skipped: failures.length + conflictFailures.length,
     ...(options.returnSuccesses ? { successes } : {}),
     metadata: options.metadata,
   });
@@ -333,6 +331,11 @@ async function patchRowWithRetry(
   row: ReadyRow,
   retries = 2
 ): Promise<PatchRowResult> {
+  const guardFailure = await checkRowGuard(ops, row);
+  if (guardFailure) {
+    return { status: 'failure', failure: guardFailure };
+  }
+
   const body = buildPatchBody(row.item);
 
   for (let attempt = 0; attempt <= retries; attempt++) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -283,6 +283,7 @@ export class PlytixClient {
       metadata: options.metadata,
       concurrency: options.concurrency,
       requestDelayMs: options.requestDelayMs,
+      returnSuccesses: options.returnSuccesses,
     });
   }
 

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -25,6 +25,8 @@ const batchUpdateItemSchema = z.object({
   label: z.string().optional(),
   status: z.string().optional(),
   attributes: z.record(z.unknown()).optional(),
+  expected_attributes: z.record(z.unknown()).optional(),
+  if_match: z.record(z.unknown()).optional(),
 });
 
 export function registerProductTools(server: McpServer, client: PlytixClient) {
@@ -580,6 +582,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   registerTool<{
     items: unknown[];
     dry_run?: boolean;
+    return_successes?: boolean;
   }>(
     server,
     'products_batch_update',
@@ -594,12 +597,17 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
           .boolean()
           .optional()
           .describe('Validate, resolve, and verify the batch without applying PATCH updates'),
+        return_successes: z
+          .boolean()
+          .optional()
+          .describe('Include one success row per patched product for exact caller ledger updates'),
       },
     },
-    async ({ items, dry_run }) => {
+    async ({ items, dry_run, return_successes }) => {
       try {
         const result = await client.batchUpdateProducts(items, {
           dryRun: dry_run === true,
+          returnSuccesses: return_successes === true,
           maxItems: STDIO_INLINE_MAX_ITEMS,
           maxBytes: STDIO_INLINE_MAX_BYTES,
         });
@@ -629,6 +637,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
   registerTool<{
     manifest_path: string;
     dry_run?: boolean;
+    return_successes?: boolean;
   }>(
     server,
     'products_batch_update_manifest',
@@ -641,13 +650,18 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
           .boolean()
           .optional()
           .describe('Validate, resolve, and verify the manifest without applying PATCH updates'),
+        return_successes: z
+          .boolean()
+          .optional()
+          .describe('Include one success row per patched product for exact caller ledger updates'),
       },
     },
-    async ({ manifest_path, dry_run }) => {
+    async ({ manifest_path, dry_run, return_successes }) => {
       try {
         const manifest = await readBatchManifest(manifest_path);
         const result = await client.batchUpdateProducts(manifest.items, {
           dryRun: dry_run === true,
+          returnSuccesses: return_successes === true,
           maxItems: MANIFEST_MAX_ITEMS,
           metadata: manifest.metadata,
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,8 @@ export interface BatchUpdateItem {
   label?: string;
   status?: string;
   attributes?: Record<string, unknown>;
+  expected_attributes?: Record<string, unknown>;
+  if_match?: Record<string, unknown>;
 }
 
 export type BatchUpdateFailureStage =
@@ -123,6 +125,7 @@ export type BatchUpdateFailureStage =
   | 'resolve'
   | 'verify'
   | 'duplicate'
+  | 'conflict'
   | 'patch';
 
 export interface BatchUpdateErrorDetail {
@@ -136,6 +139,13 @@ export interface BatchUpdateFailure {
   product_id?: string;
   stage: BatchUpdateFailureStage;
   errors: BatchUpdateErrorDetail[];
+}
+
+export interface BatchUpdateSuccess {
+  key: string;
+  index: number;
+  product_id: string;
+  modified?: string;
 }
 
 export interface BatchUpdateSummary {
@@ -163,6 +173,7 @@ export type BatchUpdateResult =
       dry_run?: boolean;
       summary: BatchUpdateSummary;
       failures: BatchUpdateFailure[];
+      successes?: BatchUpdateSuccess[];
       metadata?: BatchUpdateMetadata;
     };
 

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -352,6 +352,7 @@ export class WorkerPlytixClient {
       metadata: options.metadata,
       concurrency: options.concurrency,
       requestDelayMs: options.requestDelayMs,
+      returnSuccesses: options.returnSuccesses,
     });
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -638,12 +638,24 @@ const TOOLS: ToolDefinition[] = [
                 type: 'object',
                 description: 'Attributes to update (use attribute labels as keys, null to clear)',
               },
+              expected_attributes: {
+                type: 'object',
+                description: 'Attribute values that must still match live product data before PATCH',
+              },
+              if_match: {
+                type: 'object',
+                description: 'Top-level or attributes.* field values that must match before PATCH',
+              },
             },
           },
         },
         dry_run: {
           type: 'boolean',
           description: 'Validate, resolve, and verify the batch without applying PATCH updates',
+        },
+        return_successes: {
+          type: 'boolean',
+          description: 'Include one success row per patched product for exact caller ledger updates',
         },
       },
       required: ['items'],
@@ -1723,6 +1735,7 @@ const toolHandlers: Record<string, ToolHandler> = {
   async products_batch_update(args, client) {
     const result = await client.batchUpdateProducts(args.items, {
       dryRun: args.dry_run === true,
+      returnSuccesses: args.return_successes === true,
       maxItems: WORKER_INLINE_MAX_ITEMS,
       maxBytes: WORKER_INLINE_MAX_BYTES,
     });


### PR DESCRIPTION
## Summary
- Adds per-item optimistic-concurrency guards to batch updates:
  - `expected_attributes` compares live `product.attributes` values.
  - `if_match` compares top-level fields or `attributes.<label>` paths.
  - Guard mismatches skip the row with `stage: "conflict"` before PATCH.
- Adds opt-in `return_successes` for exact caller ledgers.
- Updates stdio and Worker tool schemas, docs, tests, and release metadata for `0.3.1`.

## Why
Batching creates a bounded drift window between the caller read and the eventual PATCH. Guarded items now re-read live product data immediately before PATCH, so stale read-modify-write rows are skipped by the MCP instead of relying only on the ETL layer.

## Notes
- This keeps the MCP stateless. Idempotency/resume remains a caller-ledger responsibility unless we later add persistent MCP state.
- Unguarded rows keep the original throughput; live guard reads are only scheduled for rows that include `expected_attributes` or `if_match`.

## Verification
- [x] `npm test` - 59 passed
- [x] `npm run typecheck`
- [x] `npm run typecheck:worker`
- [x] `npm run build`
- [x] `git diff --check`

Generated with Codex.