### PR TITLE
Add batch product export tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-06-09
+
+### Added
+- Added `products_batch_export` for capped inline product snapshots by search, SKU, or
+  product ID, available on stdio and the Worker.
+- Added stdio-only `products_batch_export_to_file` for larger JSONL/NDJSON exports under
+  `PLYTIX_MCP_EXPORT_DIR`, with canonical hashes, preview rows, path guardrails, and
+  per-row failures.
+
+### Changed
+- Documented the batch-export contract and Worker parity exception for local filesystem
+  exports.
+
 ## [0.3.1] - 2026-06-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ src/
   worker-client.ts      # Request-scoped Plytix client for the Cloudflare Worker
   types.ts              # TypeScript types for Plytix API
   worker.ts             # Cloudflare Worker MCP entry point
+  batch/                # Shared batch update/export runners and stdio-only file helpers
   lookup/
     identifier.ts       # Identifier type detection (ID, SKU, MPN, GTIN, label)
     lookup.ts           # Smart product lookup with staged search
@@ -56,6 +57,8 @@ src/
 | `products_get` | Get a single product by ID (includes `overwritten_attributes`) |
 | `products_search` | Advanced product search with filters, pagination, and sorting |
 | `products_find` | Multi-criteria search (SKU, MPN, GTIN, label, fuzzy) |
+| `products_batch_export` | Capped inline product export by search, SKU, or product ID |
+| `products_batch_export_to_file` | Stdio-only JSONL/NDJSON product export under `PLYTIX_MCP_EXPORT_DIR` |
 | `families_list` | List or search product families |
 | `families_get` | Get one product family |
 | `families_list_attributes` | List attributes directly linked to a family |
@@ -150,6 +153,8 @@ Optional:
 - `PLYTIX_AUTH_URL` - Auth endpoint (default: https://auth.plytix.com/auth/api/get-token)
 - `PLYTIX_MPN_LABELS` - JSON array of MPN attribute labels
 - `PLYTIX_MNO_LABELS` - JSON array of MNO attribute labels
+- `PLYTIX_MCP_EXPORT_DIR` - Required only for stdio `products_batch_export_to_file`;
+  file exports are restricted to this directory
 
 ## Plytix API Notes
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A **lightweight, stateless Model Context Protocol (MCP) server** that provides A
 
 ## Features
 
-- **47 MCP tools via stdio and 44 via the remote worker**
+- **51 MCP tools via stdio and 46 via the remote worker**
 - **Smart product lookup** with automatic identifier detection (SKU, MPN, GTIN, label)
 - **Family & inheritance tracking** with overwritten_attributes support
 - **Schema discovery** for attributes and search filters
@@ -98,7 +98,7 @@ npx mcp-remote https://plytix-mcp.your-subdomain.workers.dev/mcp \
   --header "X-Plytix-API-Password: YOUR_API_PASSWORD"
 ```
 
-The remote worker exposes 44 tools. It intentionally omits the three local-only identifier utilities: `identifier_detect`, `identifier_normalize`, and `match_score`.
+The remote worker exposes 46 tools. It intentionally omits local-only utilities and filesystem tools: `identifier_detect`, `identifier_normalize`, `match_score`, `products_batch_update_manifest`, and `products_batch_export_to_file`.
 
 ### Local Development
 
@@ -120,8 +120,12 @@ For detailed setup instructions, see [docs/remote-setup.md](docs/remote-setup.md
 | `products_get_full` | Get one product with related family, variants, categories, and assets |
 | `products_search` | Advanced search with filters, pagination, and sorting |
 | `products_find` | Simple multi-criteria search (SKU, MPN, MNO, GTIN, label, fuzzy) |
+| `products_batch_export` | Capped inline product snapshot by search, SKU, or product ID |
+| `products_batch_export_to_file` | Stdio-only JSONL/NDJSON product export under `PLYTIX_MCP_EXPORT_DIR` |
 | `products_create` | Create a new product |
 | `products_update` | Partial update to product fields/attributes |
+| `products_batch_update` | Apply a small guarded product-update batch |
+| `products_batch_update_manifest` | Stdio-only guarded product updates from a local JSON manifest |
 | `products_assign_family` | Assign or unassign a product family |
 | `products_set_attribute` | Atomic set of one attribute value |
 | `products_clear_attribute` | Atomic clear of one attribute value |
@@ -198,7 +202,7 @@ For detailed setup instructions, see [docs/remote-setup.md](docs/remote-setup.md
 | `identifier_normalize` | Normalize identifier for matching |
 | `match_score` | Score identifier-product match confidence |
 
-The remote worker exposes every tool above except the three identifier utilities in the final section.
+The remote worker exposes every tool above except the three identifier utilities in the final section and the two stdio-only filesystem tools: `products_batch_update_manifest` and `products_batch_export_to_file`.
 
 ## Smart Lookup System
 
@@ -245,6 +249,7 @@ Products return an `overwritten_attributes` array listing which attributes are e
 | `PLYTIX_AUTH_URL` | ❌ | `https://auth.plytix.com/auth/api/get-token` | Auth endpoint |
 | `PLYTIX_MPN_LABELS` | ❌ | `["attributes.mpn"]` | JSON array of MPN attribute labels |
 | `PLYTIX_MNO_LABELS` | ❌ | `["attributes.model_no"]` | JSON array of MNO attribute labels |
+| `PLYTIX_MCP_EXPORT_DIR` | ❌ | — | Required only for `products_batch_export_to_file`; limits file exports to this directory |
 
 ## Development
 

--- a/docs/features/batch-export/SPEC.md
+++ b/docs/features/batch-export/SPEC.md
@@ -1,0 +1,348 @@
+# SPEC - Batch Product Export tools
+
+> **Status:** Draft for review
+> **Date:** 2026-06-09
+> **Consumer:** operator/agent live Plytix snapshots for ETL and sync diffs
+
+## Summary
+
+Add batch product export tools over documented Plytix product read APIs.
+
+This is not production sync scheduling and not a replacement for `supplyline-sync`'s
+channel-feed queue. It is an operator/agent tool for live Plytix snapshots, diff prep,
+small SKU refreshes, and pre/post checks around `products_batch_update`.
+
+Tools:
+
+- **`products_batch_export`** - capped inline export for small interactive reads;
+  available on stdio and the Cloudflare Worker.
+- **`products_batch_export_to_file`** - stdio-only file export that writes JSONL/NDJSON
+  rows to disk and returns metadata, hashes, failures, and a small preview.
+
+No public first-party async product export endpoint is documented in
+`docs/solutions/api-quirks/plytix-api.md`. v1 reuses existing product reads:
+
+- `POST /api/v2/products/search`
+- `GET /api/v2/products/:product_id`
+
+If Plytix later documents a supported export/job endpoint, it may become an internal
+implementation optimization behind the same contract.
+
+## Load-bearing Constraint
+
+**Do not thread large product snapshots through the model context.**
+
+The read-side failure mode mirrors batch updates: thousands of product rows can be larger
+than the useful working context even when the API calls themselves are cheap.
+
+Consequences:
+
+- Inline export is only for small interactive reads.
+- Large exports must write rows to disk and return metadata plus a small preview.
+- The result must never echo all rows when a file export succeeds or fails.
+- The tool is for operators and agents. Production sync paths should keep using their own
+  queue/R2/import plumbing.
+
+## Selectors
+
+Both tools accept the same selector shape. Exactly one selector mode is allowed.
+
+```ts
+type ProductExportSelector =
+  | {
+      mode: "search",
+      filters?: unknown[],
+      sort?: unknown,
+      confirm_full_catalog?: boolean
+    }
+  | {
+      mode: "skus",
+      skus: string[]
+    }
+  | {
+      mode: "product_ids",
+      product_ids: string[]
+    };
+```
+
+Rules:
+
+- `mode: "search"` uses `POST /api/v2/products/search`.
+- `mode: "skus"` resolves exact SKUs with `sku in [...]`, pages through every result page,
+  and exports matched product rows.
+- `mode: "product_ids"` calls `GET /api/v2/products/:product_id` for each ID.
+- Search with no filters is rejected unless `confirm_full_catalog: true`.
+- SKU/product ID selectors preserve input order in the output where possible.
+- Duplicate `skus` or duplicate `product_ids` are rejected before API calls.
+- Ambiguous SKU matches are row failures with `stage: "resolve"`.
+- Missing SKU or missing product ID is a row failure with `stage: "resolve"` or
+  `stage: "fetch"` respectively.
+- No related entity expansion in v1. Product rows only; assets, categories, variants, and
+  relationships remain separate tools.
+
+## Shared Input Contract
+
+```ts
+type ProductBatchExportInput = ProductExportSelector & {
+  attributes?: string[];
+  max_rows?: number;
+  page_size?: number;
+  preview_rows?: number;
+};
+```
+
+Rules:
+
+- `attributes` follows existing `products_search` behavior, max 50. Custom attributes need
+  the `attributes.` prefix when Plytix requires it. It is supported for `mode: "search"`
+  and `mode: "skus"`.
+- `mode: "product_ids"` rejects `attributes` in v1 because `GET /api/v2/products/:id`
+  returns the full product and does not support server-side projection.
+- `page_size` defaults to 100 and may not exceed 100.
+- `preview_rows` defaults to 5 and may not exceed 20.
+- Inline `mode: "search"` defaults `max_rows` to the inline row cap.
+- File `mode: "search"` requires explicit `max_rows`, even with filters. This prevents
+  accidental full-catalog dumps.
+- `confirm_full_catalog: true` only permits an empty-filter search. It does not remove
+  file export's explicit `max_rows` requirement.
+- `sort` is allowed only in `mode: "search"`. Use cautiously: Plytix has documented
+  system limits around sorted result windows, so large exports should avoid order unless a
+  caller has a specific reason.
+
+## Inline Export Contract
+
+`products_batch_export` input:
+
+```ts
+ProductBatchExportInput
+```
+
+Caps:
+
+- Stdio inline: max **250 rows** and **512 KB** serialized response payload.
+- Worker inline: max **100 rows** and **256 KB** serialized response payload.
+
+Result includes `products` only when the response stays under the cap. If the row cap or
+byte cap is exceeded, return `status: "rejected"` with a clear instruction to use
+`products_batch_export_to_file` on stdio.
+
+The Worker exposes only this inline tool. It cannot write to the caller's filesystem.
+
+## File Export Contract
+
+`products_batch_export_to_file` input:
+
+```ts
+ProductBatchExportInput & {
+  output_path: string;
+  format?: "jsonl" | "ndjson";
+  overwrite?: boolean;
+}
+```
+
+Rules:
+
+- Stdio-only.
+- Default format is `jsonl`.
+- Require `.jsonl` or `.ndjson` extension.
+- Write UTF-8 only.
+- Parent directory must already exist.
+- Do not overwrite an existing file unless `overwrite: true`.
+- Write to a temporary file in the same directory, then atomically rename into place.
+- Hard cap file exports at **100,000 rows** and **256 MB** output bytes.
+- Never echo row payloads in errors. Return counts, keys, paths, and error messages only.
+- Return a small `preview` array from the first `preview_rows` products, subject to the
+  preview cap.
+
+Output file format:
+
+- One product JSON object per line.
+- No metadata header line. Keep the file directly streamable into diff tools, `jq`, or
+  ETL readers.
+- The returned `export_sha256` is the SHA-256 of the exact file bytes.
+
+## Hashes
+
+Return both:
+
+- `query_sha256` - SHA-256 of a canonical JSON object containing selector mode, filters,
+  sort, identifiers, attributes, max rows, and page size. Exclude `output_path`,
+  `overwrite`, and preview settings.
+- `export_sha256` - SHA-256 of exported product rows:
+  - inline: SHA-256 of canonical JSONL bytes for the returned products,
+  - file: SHA-256 of the exact bytes written to disk.
+
+These hashes let the caller record what was asked for and what was actually exported
+without storing row payloads in the chat transcript.
+
+## Response Shapes
+
+Rejected:
+
+```ts
+{
+  status: "rejected",
+  summary: {
+    requested?: number,
+    exported: 0,
+    failed: number,
+    truncated: boolean
+  },
+  failures: ProductBatchExportFailure[],
+  metadata?: ProductBatchExportMetadata
+}
+```
+
+Finished:
+
+```ts
+{
+  status: "finished",
+  mode: "inline" | "file",
+  products?: PlytixProduct[],
+  preview: PlytixProduct[],
+  summary: {
+    requested?: number,
+    exported: number,
+    failed: number,
+    truncated: boolean
+  },
+  failures: ProductBatchExportFailure[],
+  metadata: ProductBatchExportMetadata
+}
+```
+
+Failure:
+
+```ts
+interface ProductBatchExportFailure {
+  key: string; // sku, product_id, or search page label
+  index?: number;
+  stage: "validation" | "resolve" | "fetch" | "write" | "limit";
+  errors: Array<{ field?: string, msg: string }>;
+}
+```
+
+Metadata:
+
+```ts
+interface ProductBatchExportMetadata {
+  selector_mode: "search" | "skus" | "product_ids";
+  output_path?: string;
+  row_count: number;
+  page_size: number;
+  pages_read?: number;
+  started_at: string;
+  completed_at: string;
+  query_sha256?: string;
+  export_sha256?: string;
+  attributes_returned?: string[];
+}
+```
+
+## Mechanism
+
+### Search mode
+
+1. Validate selector, caps, and byte/file guardrails.
+2. Reject empty filter search unless `confirm_full_catalog: true`.
+3. Call `POST /api/v2/products/search` with `page_size <= 100`.
+4. Page until:
+   - Plytix reports no remaining pages,
+   - `max_rows` is reached,
+   - the file export byte cap is reached.
+5. Set `summary.truncated: true` when file export stops because of `max_rows` or the
+   file byte cap.
+6. Inline export must reject before returning if the row cap or serialized response byte
+   cap would be exceeded. Do not return partial inline products for an over-cap result.
+7. Hash the canonical query and exported rows.
+
+### SKU mode
+
+1. Reject duplicate SKUs.
+2. Resolve SKUs in chunks of 100 with exact `sku in [...]`, no `pagination.order`, and
+   page through every chunk until `pagination.pages` is exhausted.
+3. Missing SKU becomes a `resolve` failure.
+4. Multiple products for the same SKU becomes a `resolve` failure.
+5. Export resolved products in input order.
+
+### Product ID mode
+
+1. Reject duplicate product IDs.
+2. Fetch each product by `GET /api/v2/products/:product_id` with bounded concurrency and
+   request pacing.
+3. Missing or failed fetch becomes a row failure.
+4. Export fetched products in input order.
+
+## Pacing and Retries
+
+- Reuse existing auth, timeout, 401 refresh, and 429 backoff in `client.ts` and
+  `worker-client.ts`.
+- Use bounded concurrency for `product_ids` fetch mode. Default concurrency should match
+  batch update's conservative default unless tests justify otherwise.
+- Search mode is naturally page-sequential. Do not fire all pages concurrently because
+  pagination can drift under concurrent catalog changes.
+- Retry transient 5xx/timeouts a small number of times; after exhaustion, record a row
+  failure.
+
+## Drift and Snapshot Semantics
+
+This is a live API export, not a database snapshot. For high-churn catalogs, products can
+change during a multi-page export.
+
+The tool should make that explicit:
+
+- Return `started_at` and `completed_at`.
+- Return `truncated`.
+- Do not claim snapshot isolation.
+- For precise read-modify-write flows, use export output as the read side and
+  `products_batch_update` with `expected_attributes` / `if_match` as the write-side guard.
+
+## File Plan
+
+| Layer | Change |
+|---|---|
+| `src/types.ts` | Add product batch export input/result/failure metadata types. |
+| `src/batch/export.ts` *(new)* | Shared export execution, selectors, hashing, row shaping, preview handling. |
+| `src/batch/export-file.ts` *(new)* | Stdio-only JSONL writer, output guardrails, SHA-256 file hashing. |
+| `src/client.ts` | Reuse `searchProducts()` / `getProduct()`; add small wrapper if useful. |
+| `src/worker-client.ts` | Reuse existing Worker product reads for inline export. |
+| `src/tools/products.ts` | Register `products_batch_export` and stdio-only `products_batch_export_to_file`. |
+| `src/worker.ts` | Mirror `products_batch_export` only, with lower caps. |
+| `src/__tests__/batch-export.test.ts` *(new)* | Unit tests for selectors, pagination, caps, hashing, file writes, and Worker parity. |
+| `CLAUDE.md`, `README.md`, `docs/features/worker-parity/SPEC.md` | Document tool counts and stdio-only file export exception. |
+
+## Testing
+
+Unit tests with no live API:
+
+- Validation: no selector, multiple selectors, empty search without confirmation,
+  duplicate SKUs, duplicate product IDs, invalid output extension, existing output file
+  without overwrite.
+- Search pagination: reads all pages, honors `max_rows`, marks `truncated`, computes
+  `query_sha256` and `export_sha256`.
+- SKU mode: exact SKU chunking, paginated resolution, missing SKU failure, ambiguous SKU
+  failure, input order preservation.
+- Product ID mode: successful fetches, missing product failures, input order
+  preservation, retryable error handling.
+- Inline caps: row cap and serialized-byte cap reject with no row payload echo.
+- File export: writes JSONL, hashes exact file bytes, preview is capped, temp file is
+  renamed into place, failures do not include row payloads.
+- Worker parity: Worker exposes inline export and omits file export.
+
+Live verification after implementation:
+
+1. Run a tiny inline export for 2-4 known SKUs.
+2. Run a file export for the same SKUs and compare row count/hash stability.
+3. Run a filtered search export with a low `max_rows` and confirm `truncated: true`.
+4. Confirm Worker tools list includes inline export and omits file export.
+
+## Review Decisions
+
+1. Do not add a separate `products_batch_get` in v1. Deterministic `sku[]` and
+   `product_id[]` exports are selector modes on the two export tools. Add an alias later
+   only if repeated usage shows the ergonomics are worth another tool name.
+2. File-first is mandatory for large exports. The inline tool is intentionally small.
+3. Do not add related-entity expansion in v1. Product rows are the common denominator and
+   already enough for live snapshot -> diff -> guarded batch update.
+4. Do not wire this into production sync scheduling. It is an operator/agent tool.

--- a/docs/features/batch-export/SPEC.md
+++ b/docs/features/batch-export/SPEC.md
@@ -1,6 +1,6 @@
 # SPEC - Batch Product Export tools
 
-> **Status:** Draft for review
+> **Status:** Implemented
 > **Date:** 2026-06-09
 > **Consumer:** operator/agent live Plytix snapshots for ETL and sync diffs
 
@@ -72,11 +72,15 @@ Rules:
   and exports matched product rows.
 - `mode: "product_ids"` calls `GET /api/v2/products/:product_id` for each ID.
 - Search with no filters is rejected unless `confirm_full_catalog: true`.
+- Empty search means `filters` is omitted, `null`, an empty array, or only empty filter
+  groups after normalization, such as `filters: [[]]`.
 - SKU/product ID selectors preserve input order in the output where possible.
 - Duplicate `skus` or duplicate `product_ids` are rejected before API calls.
 - Ambiguous SKU matches are row failures with `stage: "resolve"`.
 - Missing SKU or missing product ID is a row failure with `stage: "resolve"` or
   `stage: "fetch"` respectively.
+- SKU matching is exact according to Plytix API filter semantics. The implementation does
+  not perform local case folding, trimming, or normalization.
 - No related entity expansion in v1. Product rows only; assets, categories, variants, and
   relationships remain separate tools.
 
@@ -96,11 +100,21 @@ Rules:
 - `attributes` follows existing `products_search` behavior, max 50. Custom attributes need
   the `attributes.` prefix when Plytix requires it. It is supported for `mode: "search"`
   and `mode: "skus"`.
+- Duplicate `attributes` are rejected before API calls. The canonical query hash stores
+  attributes as sorted unique values because projection order is not semantically
+  meaningful.
 - `mode: "product_ids"` rejects `attributes` in v1 because `GET /api/v2/products/:id`
   returns the full product and does not support server-side projection.
+- `mode: "product_ids"` rejects `page_size` because pagination does not apply to direct
+  product fetches.
 - `page_size` defaults to 100 and may not exceed 100.
 - `preview_rows` defaults to 5 and may not exceed 20.
-- Inline `mode: "search"` defaults `max_rows` to the inline row cap.
+- Inline `mode: "search"` treats explicit `max_rows <= inline_cap` as an intentional
+  limited read and may return `truncated: true`.
+- Inline `mode: "search"` with omitted `max_rows` means "small full interactive read". It
+  defaults to the inline row cap and rejects if more rows match than the cap.
+- For `mode: "skus"` and `mode: "product_ids"`, `max_rows` defaults to the identifier
+  count. If provided and lower than the identifier count, reject before API calls.
 - File `mode: "search"` requires explicit `max_rows`, even with filters. This prevents
   accidental full-catalog dumps.
 - `confirm_full_catalog: true` only permits an empty-filter search. It does not remove
@@ -143,12 +157,21 @@ ProductBatchExportInput & {
 Rules:
 
 - Stdio-only.
-- Default format is `jsonl`.
-- Require `.jsonl` or `.ndjson` extension.
+- Require `PLYTIX_MCP_EXPORT_DIR`. File export writes only under this configured export
+  root.
+- `output_path` may be relative to the export root or absolute, but the resolved real
+  parent path must be inside the resolved export root.
+- Reject `..` path segments and any resolved path or symlinked parent that escapes the
+  export root.
+- Parent directory must already exist inside the export root.
+- Default format is inferred from the extension.
+- Require `.jsonl` or `.ndjson` extension. If `format` is provided, it must match the
+  extension.
 - Write UTF-8 only.
-- Parent directory must already exist.
 - Do not overwrite an existing file unless `overwrite: true`.
-- Write to a temporary file in the same directory, then atomically rename into place.
+- Write to an exclusively created temporary file in the same resolved parent directory,
+  then atomically rename into place.
+- Clean up the temporary file on failure.
 - Hard cap file exports at **100,000 rows** and **256 MB** output bytes.
 - Never echo row payloads in errors. Return counts, keys, paths, and error messages only.
 - Return a small `preview` array from the first `preview_rows` products, subject to the
@@ -156,10 +179,31 @@ Rules:
 
 Output file format:
 
-- One product JSON object per line.
+- One canonical product JSON object per line.
 - No metadata header line. Keep the file directly streamable into diff tools, `jq`, or
   ETL readers.
 - The returned `export_sha256` is the SHA-256 of the exact file bytes.
+
+## Canonical JSON
+
+All query and export hashes use canonical JSON:
+
+- UTF-8.
+- Object keys sorted lexicographically at every depth.
+- Array order preserved.
+- Undefined object fields omitted.
+- No insignificant whitespace.
+- Strings use standard JSON escaping.
+- Numbers follow `JSON.stringify`-compatible finite JSON number rules.
+- Reject `NaN`, `Infinity`, and `-Infinity`.
+
+Canonical JSONL:
+
+- Each row is one canonical JSON object.
+- Each row is followed by `\n`, including the final row.
+- `export_sha256` is computed over those exact bytes.
+- File export writes canonical JSONL too, so inline and file hashes do not drift because
+  of object insertion order or pretty-printing differences.
 
 ## Hashes
 
@@ -184,9 +228,11 @@ Rejected:
   status: "rejected",
   summary: {
     requested?: number,
+    matched?: number,
     exported: 0,
     failed: number,
-    truncated: boolean
+    truncated: boolean,
+    limit_reason?: ProductBatchExportLimitReason
   },
   failures: ProductBatchExportFailure[],
   metadata?: ProductBatchExportMetadata
@@ -203,13 +249,26 @@ Finished:
   preview: PlytixProduct[],
   summary: {
     requested?: number,
+    matched?: number,
     exported: number,
     failed: number,
-    truncated: boolean
+    truncated: boolean,
+    limit_reason?: ProductBatchExportLimitReason
   },
   failures: ProductBatchExportFailure[],
   metadata: ProductBatchExportMetadata
 }
+```
+
+Limit reason:
+
+```ts
+type ProductBatchExportLimitReason =
+  | "max_rows"
+  | "file_byte_cap"
+  | "inline_row_cap"
+  | "inline_byte_cap"
+  | "api_window_limit";
 ```
 
 Failure:
@@ -236,9 +295,15 @@ interface ProductBatchExportMetadata {
   completed_at: string;
   query_sha256?: string;
   export_sha256?: string;
-  attributes_returned?: string[];
+  attributes_requested?: string[];
+  attributes_returned_observed?: string[];
+  format?: "jsonl" | "ndjson";
 }
 ```
+
+`summary.requested` is the input identifier count for `skus` and `product_ids`. For
+search mode, `summary.matched` is the Plytix total match count only when the API provides
+it; do not invent one.
 
 ## Mechanism
 
@@ -262,9 +327,13 @@ interface ProductBatchExportMetadata {
 1. Reject duplicate SKUs.
 2. Resolve SKUs in chunks of 100 with exact `sku in [...]`, no `pagination.order`, and
    page through every chunk until `pagination.pages` is exhausted.
-3. Missing SKU becomes a `resolve` failure.
-4. Multiple products for the same SKU becomes a `resolve` failure.
-5. Export resolved products in input order.
+3. Always request enough internal fields to identify `product_id` and `sku`, even when
+   the caller did not request them. Internal resolver fields may be used for matching,
+   ordering, and failure detection; do not inject them into custom attributes unless the
+   caller requested them.
+4. Missing SKU becomes a `resolve` failure.
+5. Multiple products for the same SKU becomes a `resolve` failure.
+6. Export resolved products in input order.
 
 ### Product ID mode
 
@@ -273,6 +342,21 @@ interface ProductBatchExportMetadata {
    request pacing.
 3. Missing or failed fetch becomes a row failure.
 4. Export fetched products in input order.
+
+## Failure Semantics
+
+| Scenario | Status | Final file? | Notes |
+|---|---|---|---|
+| Validation failure | `rejected` | No | No API calls. |
+| Inline cap exceeded | `rejected` | No | No row payloads. |
+| File write failure | `rejected` | No | Temp file is cleaned up. |
+| SKU missing/ambiguous | `finished` | Yes | Export successes only and report per-SKU failures. |
+| Product ID missing/fetch failed | `finished` | Yes | Export successes only and report per-product failures. |
+| Search page fetch failure after retries | `rejected` | No | Partial search output is unsafe for diff workflows. |
+| Search hits `max_rows` or file byte cap | `finished` | Yes | `truncated: true` with `limit_reason`. |
+
+Deterministic `skus` and `product_ids` exports should reject instead of returning partial
+output when the selector itself exceeds row caps or when file bytes exceed the hard cap.
 
 ## Pacing and Retries
 

--- a/docs/features/worker-parity/SPEC.md
+++ b/docs/features/worker-parity/SPEC.md
@@ -6,16 +6,17 @@
 
 The Cloudflare Worker MCP server now exposes the full API-backed tool surface.
 
-- `stdio`: 49 tools
-- `remote worker`: 45 tools
+- `stdio`: 51 tools
+- `remote worker`: 46 tools
 - intentional remote omissions: `identifier_detect`, `identifier_normalize`, `match_score`,
-  `products_batch_update_manifest`
+  `products_batch_update_manifest`, `products_batch_export_to_file`
 
 The three identifier tools remain stdio-only because they are pure local utilities. Remote
 clients should use `products_lookup`, which already incorporates the same identifier logic
-for the practical lookup flow. `products_batch_update_manifest` is stdio-only because it
-reads a user-local JSON file; the Worker has no caller filesystem access and exposes the
-inline `products_batch_update` tool with lower caps instead.
+for the practical lookup flow. `products_batch_update_manifest` and
+`products_batch_export_to_file` are stdio-only because they read from or write to the
+user's local filesystem; the Worker has no caller filesystem access and exposes the inline
+batch tools with lower caps instead.
 
 ## Current Parity Rules
 
@@ -32,7 +33,8 @@ inline `products_batch_update` tool with lower caps instead.
 | `identifier_normalize` | Pure utility for string normalization |
 | `match_score` | Pure utility for local identifier-to-product scoring |
 | `products_batch_update_manifest` | Reads a local JSON manifest from the user's filesystem |
+| `products_batch_export_to_file` | Writes a local JSONL/NDJSON export under `PLYTIX_MCP_EXPORT_DIR` |
 
 ## Historical Note
 
-The earlier worker parity gap around product writes, attribute metadata reads, category linking, and attribute validation has already been closed. This document now records the steady-state contract: remote mirrors stdio except for the local identifier helpers and the local-filesystem manifest batch tool above.
+The earlier worker parity gap around product writes, attribute metadata reads, category linking, and attribute validation has already been closed. This document now records the steady-state contract: remote mirrors stdio except for the local identifier helpers and the local-filesystem batch tools above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plytix-mcp-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "MCP server for Plytix PIM API integration. Enables AI assistants to read, write, and manage product data, assets, categories, and relationships.",
   "keywords": [

--- a/src/__tests__/batch-export.test.ts
+++ b/src/__tests__/batch-export.test.ts
@@ -1,0 +1,295 @@
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import worker from '../worker.js';
+import {
+  canonicalJson,
+  executeBatchExport,
+  type ProductExportOperations,
+  type ProductExportSink,
+} from '../batch/export.js';
+import { exportProductsToFile } from '../batch/export-file.js';
+import type { PlytixProduct, PlytixResult, PlytixSearchBody } from '../types.js';
+
+const searchFilter = [[{ field: 'status', operator: 'eq', value: 'ACTIVE' }]];
+
+function makeOps(args?: {
+  search?: (body: PlytixSearchBody) => Promise<PlytixResult<PlytixProduct>>;
+  get?: (productId: string) => Promise<PlytixResult<PlytixProduct>>;
+}): ProductExportOperations & {
+  searchProducts: ReturnType<typeof vi.fn>;
+  getProduct: ReturnType<typeof vi.fn>;
+} {
+  return {
+    searchProducts: vi.fn(async (body: PlytixSearchBody) =>
+      args?.search
+        ? args.search(body)
+        : {
+            data: [],
+            pagination: { page: body.pagination?.page ?? 1, page_size: 100, total: 0, pages: 1 },
+          }
+    ),
+    getProduct: vi.fn(async (productId: string) =>
+      args?.get ? args.get(productId) : { data: [{ id: productId }] }
+    ),
+  };
+}
+
+describe('canonical JSON', () => {
+  it('sorts object keys at every depth and preserves array order', () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, b: 1 }, rows: [{ b: 2, a: 1 }] })).toBe(
+      '{"a":{"b":1,"y":2},"rows":[{"a":1,"b":2}],"z":1}'
+    );
+  });
+
+  it('rejects non-finite numbers', () => {
+    expect(() => canonicalJson({ value: Number.NaN })).toThrow('non-finite');
+  });
+});
+
+describe('executeBatchExport', () => {
+  it('allows explicit limited inline search reads and marks truncation', async () => {
+    const ops = makeOps({
+      search: async () => ({
+        data: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        pagination: { page: 1, page_size: 100, total: 3, pages: 1 },
+      }),
+    });
+
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'search', filters: searchFilter, max_rows: 2 },
+      { mode: 'inline', maxRows: 5, maxResponseBytes: 1024 * 1024 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toMatchObject({
+      exported: 2,
+      matched: 3,
+      truncated: true,
+      limit_reason: 'max_rows',
+    });
+    expect(result.products?.map((product) => product.id)).toEqual(['1', '2']);
+  });
+
+  it('rejects omitted max_rows inline searches that exceed the inline row cap', async () => {
+    const ops = makeOps({
+      search: async () => ({
+        data: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        pagination: { page: 1, page_size: 100, total: 3, pages: 1 },
+      }),
+    });
+
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'search', filters: searchFilter },
+      { mode: 'inline', maxRows: 2, maxResponseBytes: 1024 * 1024 }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.summary).toMatchObject({
+      exported: 0,
+      matched: 3,
+      limit_reason: 'inline_row_cap',
+    });
+    expect('products' in result).toBe(false);
+  });
+
+  it('pages SKU resolution and reports missing or ambiguous SKUs as row failures', async () => {
+    const ops = makeOps({
+      search: async (body) => {
+        if ((body.pagination?.page ?? 1) === 1) {
+          return {
+            data: [
+              { id: 'good-product', sku: 'GOOD' },
+              { id: 'dup-product-1', sku: 'DUP' },
+            ],
+            attributes: ['sku', 'attributes.foo'],
+            pagination: { page: 1, page_size: 100, total: 3, pages: 2 },
+          };
+        }
+        return {
+          data: [{ id: 'dup-product-2', sku: 'DUP' }],
+          attributes: ['sku', 'attributes.foo'],
+          pagination: { page: 2, page_size: 100, total: 3, pages: 2 },
+        };
+      },
+    });
+
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'skus', skus: ['GOOD', 'MISSING', 'DUP'], attributes: ['attributes.foo'] },
+      { mode: 'inline', maxRows: 10, maxResponseBytes: 1024 * 1024 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toMatchObject({ requested: 3, exported: 1, failed: 2 });
+    expect(result.failures.map((failure) => failure.key)).toEqual(['MISSING', 'DUP']);
+    expect(result.products?.map((product) => product.id)).toEqual(['good-product']);
+    expect(ops.searchProducts).toHaveBeenCalledTimes(2);
+    expect(ops.searchProducts.mock.calls[0]?.[0].attributes).toEqual([
+      'sku',
+      'attributes.foo',
+    ]);
+  });
+
+  it('rejects page_size for product_id exports', async () => {
+    const result = await executeBatchExport(
+      makeOps(),
+      { mode: 'product_ids', product_ids: ['product-1'], page_size: 10 },
+      { mode: 'inline', maxRows: 10, maxResponseBytes: 1024 * 1024 }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.failures[0]?.errors[0]?.field).toBe('page_size');
+  });
+
+  it('rejects stray selector fields before API calls', async () => {
+    const ops = makeOps();
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'search', filters: searchFilter, max_rows: 1, skus: ['SKU1'] },
+      { mode: 'inline', maxRows: 10, maxResponseBytes: 1024 * 1024 }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.failures[0]?.errors[0]?.field).toBe('skus');
+    expect(ops.searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('exports product_id successes and row-level fetch failures in input order', async () => {
+    const ops = makeOps({
+      get: async (productId) => ({
+        data: productId === 'missing-product' ? [] : [{ id: productId, label: productId }],
+      }),
+    });
+
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'product_ids', product_ids: ['product-1', 'missing-product', 'product-2'] },
+      { mode: 'inline', maxRows: 10, maxResponseBytes: 1024 * 1024, requestDelayMs: 0 }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toMatchObject({ requested: 3, exported: 2, failed: 1 });
+    expect(result.products?.map((product) => product.id)).toEqual(['product-1', 'product-2']);
+    expect(result.failures[0]).toMatchObject({ key: 'missing-product', stage: 'fetch' });
+  });
+
+  it('returns a structured rejection when the export sink cannot finish', async () => {
+    const sink: ProductExportSink = {
+      accept: vi.fn(async () => undefined),
+      finish: vi.fn(async () => {
+        throw new Error('disk full');
+      }),
+      abort: vi.fn(async () => undefined),
+    };
+    const ops = makeOps({
+      search: async () => ({
+        data: [{ id: 'product-1' }],
+        pagination: { page: 1, page_size: 100, total: 1, pages: 1 },
+      }),
+    });
+
+    const result = await executeBatchExport(
+      ops,
+      { mode: 'search', filters: searchFilter, max_rows: 1 },
+      { mode: 'file', maxRows: 10, sink }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.failures[0]).toMatchObject({ key: 'output_path', stage: 'write' });
+    expect(sink.abort).toHaveBeenCalled();
+  });
+});
+
+describe('exportProductsToFile', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  async function makeTempDir() {
+    tempDir = await mkdtemp(join(tmpdir(), 'plytix-export-'));
+    return tempDir;
+  }
+
+  it('rejects output paths outside the configured export root before API calls', async () => {
+    const root = await makeTempDir();
+    const ops = makeOps();
+
+    const result = await exportProductsToFile(
+      ops,
+      {
+        mode: 'search',
+        filters: searchFilter,
+        max_rows: 10,
+        output_path: '../escape.jsonl',
+      },
+      { exportRoot: root }
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.failures[0]?.stage).toBe('validation');
+    expect(ops.searchProducts).not.toHaveBeenCalled();
+  });
+
+  it('writes canonical JSONL under the configured export root', async () => {
+    const root = await makeTempDir();
+    const ops = makeOps({
+      search: async () => ({
+        data: [
+          { id: 'product-1', attributes: { z: 2, a: 1 } },
+          { id: 'product-2', sku: 'SKU2' },
+        ],
+        pagination: { page: 1, page_size: 100, total: 2, pages: 1 },
+      }),
+    });
+
+    const result = await exportProductsToFile(
+      ops,
+      {
+        mode: 'search',
+        filters: searchFilter,
+        max_rows: 10,
+        output_path: 'snapshot.jsonl',
+      },
+      { exportRoot: root }
+    );
+
+    expect(result.status).toBe('finished');
+    expect(result.summary).toMatchObject({ exported: 2, failed: 0, truncated: false });
+    expect(result.metadata.output_path).toBe(join(await realpath(root), 'snapshot.jsonl'));
+    expect(result.metadata.export_sha256).toMatch(/^[a-f0-9]{64}$/);
+
+    const body = await readFile(join(root, 'snapshot.jsonl'), 'utf8');
+    expect(body).toBe(
+      '{"attributes":{"a":1,"z":2},"id":"product-1"}\n{"id":"product-2","sku":"SKU2"}\n'
+    );
+  });
+});
+
+describe('worker batch export surface', () => {
+  it('exposes inline batch export and omits the stdio-only file export tool', async () => {
+    const response = await worker.fetch(
+      new Request('https://mcp.example.com/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any
+    );
+
+    const body = await response.json() as { result: { tools: Array<{ name: string }> } };
+    const toolNames = body.result.tools.map((tool) => tool.name);
+
+    expect(toolNames).toContain('products_batch_export');
+    expect(toolNames).not.toContain('products_batch_export_to_file');
+  });
+});

--- a/src/batch/export-file.ts
+++ b/src/batch/export-file.ts
@@ -1,0 +1,244 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { link, open, realpath, rename, rm, stat } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path';
+import type {
+  PlytixProduct,
+  ProductBatchExportFormat,
+  ProductBatchExportResult,
+  ProductBatchExportToFileInput,
+} from '../types.js';
+import {
+  DEFAULT_EXPORT_PAGE_SIZE,
+  FILE_EXPORT_MAX_BYTES,
+  FILE_EXPORT_MAX_ROWS,
+  type ProductExportOperations,
+  type ProductExportSink,
+  type ProductExportSinkResult,
+  canonicalJsonLine,
+  executeBatchExport,
+} from './export.js';
+
+interface ResolvedExportPath {
+  finalPath: string;
+  parentPath: string;
+  format: ProductBatchExportFormat;
+  overwrite: boolean;
+}
+
+export async function exportProductsToFile(
+  ops: ProductExportOperations,
+  rawInput: ProductBatchExportToFileInput,
+  options: { exportRoot?: string } = {}
+): Promise<ProductBatchExportResult> {
+  const startedAt = new Date().toISOString();
+  let resolved: ResolvedExportPath;
+  try {
+    resolved = await resolveExportPath(rawInput, options.exportRoot);
+  } catch (error) {
+    return {
+      status: 'rejected',
+      summary: {
+        exported: 0,
+        failed: 1,
+        truncated: false,
+      },
+      failures: [
+        {
+          key: 'output_path',
+          stage: 'validation',
+          errors: [{ field: 'output_path', msg: error instanceof Error ? error.message : String(error) }],
+        },
+      ],
+      metadata: {
+        selector_mode: readMode(rawInput),
+        row_count: 0,
+        page_size: rawInput.page_size ?? DEFAULT_EXPORT_PAGE_SIZE,
+        started_at: startedAt,
+        completed_at: new Date().toISOString(),
+      },
+    };
+  }
+
+  const sink = new FileProductExportSink(resolved, rawInput.preview_rows);
+  return executeBatchExport(ops, rawInput, {
+    mode: 'file',
+    maxRows: FILE_EXPORT_MAX_ROWS,
+    maxFileBytes: FILE_EXPORT_MAX_BYTES,
+    sink,
+    metadata: {
+      output_path: resolved.finalPath,
+      format: resolved.format,
+    },
+  });
+}
+
+class FileProductExportSink implements ProductExportSink {
+  private handle?: FileHandle;
+  private tempPath?: string;
+  private readonly hash = createHash('sha256');
+  private readonly preview: PlytixProduct[] = [];
+  private readonly maxBytes = FILE_EXPORT_MAX_BYTES;
+  private bytesWritten = 0;
+  private rowCount = 0;
+
+  constructor(
+    private readonly output: ResolvedExportPath,
+    private readonly previewRows = 5
+  ) {}
+
+  async accept(product: PlytixProduct): Promise<'file_byte_cap' | undefined> {
+    const line = canonicalJsonLine(product);
+    const lineBytes = Buffer.byteLength(line, 'utf8');
+    if (this.bytesWritten + lineBytes > this.maxBytes) {
+      return 'file_byte_cap';
+    }
+
+    await this.ensureOpen();
+    await this.handle!.write(line, undefined, 'utf8');
+    this.hash.update(line, 'utf8');
+    this.bytesWritten += lineBytes;
+    this.rowCount += 1;
+    if (this.preview.length < this.previewRows) {
+      this.preview.push(product);
+    }
+    return undefined;
+  }
+
+  async finish(): Promise<ProductExportSinkResult> {
+    await this.ensureOpen();
+    await this.handle!.close();
+    this.handle = undefined;
+
+    try {
+      if (this.output.overwrite) {
+        await rename(this.tempPath!, this.output.finalPath);
+      } else {
+        await link(this.tempPath!, this.output.finalPath);
+        await rm(this.tempPath!, { force: true });
+      }
+      this.tempPath = undefined;
+    } catch (error) {
+      await this.abort();
+      throw error;
+    }
+
+    return {
+      preview: this.preview,
+      rowCount: this.rowCount,
+      exportSha256: this.hash.digest('hex'),
+      outputPath: this.output.finalPath,
+      format: this.output.format,
+    };
+  }
+
+  async abort(): Promise<void> {
+    if (this.handle) {
+      await this.handle.close().catch(() => undefined);
+      this.handle = undefined;
+    }
+    if (this.tempPath) {
+      await rm(this.tempPath, { force: true }).catch(() => undefined);
+      this.tempPath = undefined;
+    }
+  }
+
+  private async ensureOpen(): Promise<void> {
+    if (this.handle) return;
+    this.tempPath = join(
+      this.output.parentPath,
+      `.${basename(this.output.finalPath)}.${randomUUID()}.tmp`
+    );
+    this.handle = await open(this.tempPath, 'wx');
+  }
+}
+
+async function resolveExportPath(
+  input: ProductBatchExportToFileInput,
+  exportRootOverride?: string
+): Promise<ResolvedExportPath> {
+  const exportRoot = exportRootOverride ?? process.env.PLYTIX_MCP_EXPORT_DIR;
+  if (!exportRoot) {
+    throw new Error('PLYTIX_MCP_EXPORT_DIR is required for file exports');
+  }
+  if (!input.output_path || typeof input.output_path !== 'string') {
+    throw new Error('output_path must be a non-empty string');
+  }
+  if (input.output_path.split(/[\\/]+/).includes('..')) {
+    throw new Error('output_path must not contain .. segments');
+  }
+
+  const rootReal = await realpath(exportRoot);
+  const requestedPath = isAbsolute(input.output_path)
+    ? resolve(input.output_path)
+    : resolve(rootReal, input.output_path);
+  const extension = extname(requestedPath).toLowerCase();
+  if (extension !== '.jsonl' && extension !== '.ndjson') {
+    throw new Error('output_path must end in .jsonl or .ndjson');
+  }
+
+  const inferredFormat = extension.slice(1) as ProductBatchExportFormat;
+  if (input.format !== undefined && input.format !== inferredFormat) {
+    throw new Error(`format ${input.format} does not match ${extension} output_path`);
+  }
+
+  let parentReal: string;
+  try {
+    parentReal = await realpath(dirname(requestedPath));
+  } catch {
+    throw new Error('output_path parent directory must already exist inside export root');
+  }
+  if (!isInside(rootReal, parentReal)) {
+    throw new Error('output_path parent resolves outside PLYTIX_MCP_EXPORT_DIR');
+  }
+
+  const finalPath = join(parentReal, basename(requestedPath));
+  if (!isInside(rootReal, finalPath)) {
+    throw new Error('output_path resolves outside PLYTIX_MCP_EXPORT_DIR');
+  }
+
+  if (!input.overwrite) {
+    try {
+      await stat(finalPath);
+      throw new Error('output_path already exists; pass overwrite: true to replace it');
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        // The final create is still protected with link(2), so this is only a friendly
+        // early error path.
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    finalPath,
+    parentPath: parentReal,
+    format: inferredFormat,
+    overwrite: input.overwrite === true,
+  };
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !rel.startsWith(sep) && !isAbsolute(rel));
+}
+
+function readMode(input: ProductBatchExportToFileInput): 'search' | 'skus' | 'product_ids' {
+  return input.mode === 'search' || input.mode === 'skus' || input.mode === 'product_ids'
+    ? input.mode
+    : 'search';
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/src/batch/export.ts
+++ b/src/batch/export.ts
@@ -1,0 +1,1051 @@
+import type {
+  BatchUpdateErrorDetail,
+  PlytixProduct,
+  PlytixResult,
+  PlytixSearchBody,
+  ProductBatchExportFailure,
+  ProductBatchExportFormat,
+  ProductBatchExportInput,
+  ProductBatchExportLimitReason,
+  ProductBatchExportMetadata,
+  ProductBatchExportResult,
+  ProductBatchExportSummary,
+} from '../types.js';
+import {
+  DEFAULT_BATCH_CONCURRENCY,
+  DEFAULT_BATCH_REQUEST_DELAY_MS,
+  measureSerializedBytes,
+  parsePlytixErrors,
+  runWithConcurrency,
+} from './helpers.js';
+
+export const STDIO_EXPORT_INLINE_MAX_ROWS = 250;
+export const WORKER_EXPORT_INLINE_MAX_ROWS = 100;
+export const FILE_EXPORT_MAX_ROWS = 100_000;
+export const FILE_EXPORT_MAX_BYTES = 256 * 1024 * 1024;
+export const STDIO_EXPORT_INLINE_MAX_BYTES = 512 * 1024;
+export const WORKER_EXPORT_INLINE_MAX_BYTES = 256 * 1024;
+export const DEFAULT_EXPORT_PAGE_SIZE = 100;
+export const MAX_EXPORT_PAGE_SIZE = 100;
+export const DEFAULT_EXPORT_PREVIEW_ROWS = 5;
+export const MAX_EXPORT_PREVIEW_ROWS = 20;
+export const MAX_EXPORT_ATTRIBUTES = 50;
+
+export interface ProductExportOperations {
+  searchProducts(body: PlytixSearchBody): Promise<PlytixResult<PlytixProduct>>;
+  getProduct(productId: string): Promise<PlytixResult<PlytixProduct>>;
+}
+
+export interface ExecuteBatchExportOptions {
+  mode: 'inline' | 'file';
+  maxRows: number;
+  maxResponseBytes?: number;
+  maxFileBytes?: number;
+  sink?: ProductExportSink;
+  metadata?: Partial<ProductBatchExportMetadata>;
+  concurrency?: number;
+  requestDelayMs?: number;
+}
+
+export interface ProductExportSinkResult {
+  products?: PlytixProduct[];
+  preview: PlytixProduct[];
+  rowCount: number;
+  exportSha256?: string;
+  outputPath?: string;
+  format?: ProductBatchExportFormat;
+}
+
+export interface ProductExportSink {
+  accept(product: PlytixProduct): Promise<ProductBatchExportLimitReason | undefined>;
+  finish(): Promise<ProductExportSinkResult>;
+  abort(): Promise<void>;
+}
+
+type NormalizedInput =
+  | {
+      mode: 'search';
+      filters?: PlytixSearchBody['filters'];
+      sort?: unknown;
+      confirmFullCatalog: boolean;
+      attributes?: string[];
+      maxRows: number;
+      maxRowsExplicit: boolean;
+      pageSize: number;
+      previewRows: number;
+      querySha256?: string;
+    }
+  | {
+      mode: 'skus';
+      skus: string[];
+      attributes?: string[];
+      maxRows: number;
+      maxRowsExplicit: boolean;
+      pageSize: number;
+      previewRows: number;
+      querySha256?: string;
+    }
+  | {
+      mode: 'product_ids';
+      productIds: string[];
+      maxRows: number;
+      maxRowsExplicit: boolean;
+      pageSize: number;
+      previewRows: number;
+      querySha256?: string;
+    };
+
+interface ValidationResult {
+  input?: NormalizedInput;
+  failures: ProductBatchExportFailure[];
+  requested?: number;
+}
+
+interface ExportState {
+  failures: ProductBatchExportFailure[];
+  pagesRead: number;
+  matched?: number;
+  truncated: boolean;
+  limitReason?: ProductBatchExportLimitReason;
+  attributesObserved: Set<string>;
+}
+
+export class InlineProductExportSink implements ProductExportSink {
+  private readonly products: PlytixProduct[] = [];
+  private readonly preview: PlytixProduct[] = [];
+
+  constructor(private readonly previewRows: number) {}
+
+  async accept(product: PlytixProduct): Promise<undefined> {
+    this.products.push(product);
+    if (this.preview.length < this.previewRows) {
+      this.preview.push(product);
+    }
+    return undefined;
+  }
+
+  async finish(): Promise<ProductExportSinkResult> {
+    return {
+      products: this.products,
+      preview: this.preview,
+      rowCount: this.products.length,
+      exportSha256: await sha256Hex(this.products.map(canonicalJsonLine).join('')),
+    };
+  }
+
+  async abort(): Promise<void> {
+    this.products.length = 0;
+    this.preview.length = 0;
+  }
+}
+
+export async function executeBatchExport(
+  ops: ProductExportOperations,
+  rawInput: unknown,
+  options: ExecuteBatchExportOptions
+): Promise<ProductBatchExportResult> {
+  const startedAt = new Date().toISOString();
+  const validation = await validateExportInput(rawInput, options);
+
+  if (!validation.input) {
+    return rejectedExport({
+      requested: validation.requested,
+      failures: validation.failures,
+      startedAt,
+      selectorMode: readSelectorMode(rawInput),
+    });
+  }
+
+  const input = validation.input;
+  const attributesRequested = getAttributesRequested(input);
+  const sink = options.sink ?? new InlineProductExportSink(input.previewRows);
+  const state: ExportState = {
+    failures: [],
+    pagesRead: 0,
+    truncated: false,
+    attributesObserved: new Set<string>(),
+  };
+
+  try {
+    if (input.mode === 'search') {
+      await exportBySearch(ops, input, sink, state, options);
+    } else if (input.mode === 'skus') {
+      await exportBySkus(ops, input, sink, state, options);
+    } else {
+      await exportByProductIds(ops, input, sink, state, options);
+    }
+  } catch (error) {
+    await sink.abort();
+    const limitReason = readLimitReason(error);
+    return rejectedExport({
+      requested: getRequested(input),
+      matched: state.matched,
+      failures: [
+        ...state.failures,
+        {
+          key: input.mode === 'search' ? `search:page:${state.pagesRead + 1}` : input.mode,
+          stage: limitReason ? 'limit' : input.mode === 'search' ? 'fetch' : 'write',
+          errors: parsePlytixErrors(error),
+        },
+      ],
+      startedAt,
+      selectorMode: input.mode,
+      querySha256: input.querySha256,
+      pageSize: input.pageSize,
+      pagesRead: state.pagesRead,
+      attributesRequested,
+      ...(limitReason ? { limitReason } : {}),
+    });
+  }
+
+  let sinkResult: ProductExportSinkResult;
+  try {
+    sinkResult = await sink.finish();
+  } catch (error) {
+    await sink.abort();
+    return rejectedExport({
+      requested: getRequested(input),
+      matched: state.matched,
+      failures: [
+        ...state.failures,
+        {
+          key: options.mode === 'file' ? 'output_path' : 'batch_export',
+          stage: 'write',
+          errors: parsePlytixErrors(error),
+        },
+      ],
+      startedAt,
+      selectorMode: input.mode,
+      querySha256: input.querySha256,
+      pageSize: input.pageSize,
+      pagesRead: state.pagesRead,
+      attributesRequested,
+    });
+  }
+  const completedAt = new Date().toISOString();
+  const metadata: ProductBatchExportMetadata = {
+    selector_mode: input.mode,
+    row_count: sinkResult.rowCount,
+    page_size: input.pageSize,
+    started_at: startedAt,
+    completed_at: completedAt,
+    query_sha256: input.querySha256,
+    ...(sinkResult.exportSha256 ? { export_sha256: sinkResult.exportSha256 } : {}),
+    ...(sinkResult.outputPath ? { output_path: sinkResult.outputPath } : {}),
+    ...(sinkResult.format ? { format: sinkResult.format } : {}),
+    ...(state.pagesRead ? { pages_read: state.pagesRead } : {}),
+    ...(attributesRequested ? { attributes_requested: attributesRequested } : {}),
+    ...(state.attributesObserved.size > 0
+      ? { attributes_returned_observed: Array.from(state.attributesObserved).sort() }
+      : {}),
+    ...options.metadata,
+  };
+  const summary: ProductBatchExportSummary = {
+    requested: getRequested(input),
+    ...(state.matched !== undefined ? { matched: state.matched } : {}),
+    exported: sinkResult.rowCount,
+    failed: state.failures.length,
+    truncated: state.truncated,
+    ...(state.limitReason ? { limit_reason: state.limitReason } : {}),
+  };
+
+  const result: ProductBatchExportResult = {
+    status: 'finished',
+    mode: options.mode,
+    ...(options.mode === 'inline' ? { products: sinkResult.products ?? [] } : {}),
+    preview: sinkResult.preview,
+    summary,
+    failures: state.failures,
+    metadata,
+  };
+
+  if (options.mode === 'inline' && options.maxResponseBytes !== undefined) {
+    const responseBytes = measureSerializedBytes(result);
+    if (responseBytes > options.maxResponseBytes) {
+      await sink.abort();
+      return rejectedExport({
+        requested: getRequested(input),
+        matched: state.matched,
+        failures: [
+          makeFailure(
+            'batch_export',
+            'limit',
+            `inline response is ${responseBytes} bytes; max is ${options.maxResponseBytes}`
+          ),
+        ],
+        startedAt,
+        selectorMode: input.mode,
+        querySha256: input.querySha256,
+        pageSize: input.pageSize,
+        pagesRead: state.pagesRead,
+        attributesRequested,
+        limitReason: 'inline_byte_cap',
+      });
+    }
+  }
+
+  return result;
+}
+
+async function exportBySearch(
+  ops: ProductExportOperations,
+  input: Extract<NormalizedInput, { mode: 'search' }>,
+  sink: ProductExportSink,
+  state: ExportState,
+  options: ExecuteBatchExportOptions
+): Promise<void> {
+  let page = 1;
+  let exported = 0;
+  let stop = false;
+
+  while (!stop && exported < input.maxRows) {
+    const remaining = input.maxRows - exported;
+    const result = await searchProductsWithRetry(ops, {
+      ...(input.filters ? { filters: input.filters } : {}),
+      ...(input.attributes ? { attributes: input.attributes } : {}),
+      ...(input.sort !== undefined ? { sort: input.sort } : {}),
+      pagination: { page, page_size: input.pageSize },
+    });
+
+    state.pagesRead += 1;
+    observeReturnedAttributes(result, state.attributesObserved);
+    if (result.pagination?.total !== undefined) {
+      state.matched = result.pagination.total;
+    }
+
+    const products = result.data ?? [];
+    const selected = products.slice(0, remaining);
+
+    for (const product of selected) {
+      const limitReason = await sink.accept(product);
+      if (limitReason) {
+        if (options.mode === 'file') {
+          state.truncated = true;
+          state.limitReason = limitReason;
+          stop = true;
+          break;
+        }
+        throw makeLimitError(limitReason, 'inline export exceeded its byte cap');
+      }
+      exported += 1;
+    }
+
+    const hasUnselectedRows = products.length > selected.length;
+    const hasMorePages = hasMoreSearchPages(result, page, exported);
+    if (hasUnselectedRows || (exported >= input.maxRows && hasMorePages)) {
+      state.truncated = true;
+      state.limitReason = 'max_rows';
+      stop = true;
+    } else if (!hasMorePages) {
+      stop = true;
+    } else {
+      page += 1;
+    }
+  }
+
+  if (
+    options.mode === 'inline' &&
+    !input.maxRowsExplicit &&
+    state.truncated &&
+    state.limitReason === 'max_rows'
+  ) {
+    await sink.abort();
+    throw makeLimitError('inline_row_cap', 'inline search matched more rows than the inline cap');
+  }
+}
+
+async function exportBySkus(
+  ops: ProductExportOperations,
+  input: Extract<NormalizedInput, { mode: 'skus' }>,
+  sink: ProductExportSink,
+  state: ExportState,
+  options: ExecuteBatchExportOptions
+): Promise<void> {
+  const bySku = new Map<string, PlytixProduct[]>();
+  const attributes = input.attributes ? Array.from(new Set(['sku', ...input.attributes])) : ['sku'];
+  const chunkSize = input.pageSize;
+
+  for (let i = 0; i < input.skus.length; i += chunkSize) {
+    const batch = input.skus.slice(i, i + chunkSize);
+    let page = 1;
+    let totalPages = 1;
+
+    do {
+      const result = await searchProductsWithRetry(ops, {
+        filters: [[{ field: 'sku', operator: 'in', value: batch }]],
+        attributes,
+        pagination: { page, page_size: chunkSize },
+      });
+
+      state.pagesRead += 1;
+      observeReturnedAttributes(result, state.attributesObserved);
+      for (const product of result.data ?? []) {
+        if (typeof product.sku !== 'string') continue;
+        bySku.set(product.sku, [...(bySku.get(product.sku) ?? []), product]);
+      }
+
+      totalPages = Math.max(result.pagination?.pages ?? 1, 1);
+      page += 1;
+    } while (page <= totalPages);
+  }
+
+  for (let index = 0; index < input.skus.length; index += 1) {
+    const sku = input.skus[index];
+    const matches = bySku.get(sku) ?? [];
+    if (matches.length === 0) {
+      state.failures.push(makeFailure(sku, 'resolve', `SKU not found: ${sku}`, 'sku', index));
+      continue;
+    }
+    if (matches.length > 1) {
+      state.failures.push(
+        makeFailure(sku, 'resolve', `SKU resolved to multiple products: ${sku}`, 'sku', index)
+      );
+      continue;
+    }
+
+    await acceptDeterministicProduct(sink, matches[0], input.mode);
+  }
+}
+
+async function exportByProductIds(
+  ops: ProductExportOperations,
+  input: Extract<NormalizedInput, { mode: 'product_ids' }>,
+  sink: ProductExportSink,
+  state: ExportState,
+  options: ExecuteBatchExportOptions
+): Promise<void> {
+  const results = await runWithConcurrency(
+    input.productIds.map((productId, index) => ({ productId, index })),
+    {
+      concurrency: options.concurrency ?? DEFAULT_BATCH_CONCURRENCY,
+      requestDelayMs: options.requestDelayMs ?? DEFAULT_BATCH_REQUEST_DELAY_MS,
+    },
+    async ({ productId, index }) => {
+      try {
+        const result = await getProductWithRetry(ops, productId);
+        const product = result.data?.[0];
+        if (!product?.id) {
+          return {
+            product: undefined,
+            failure: makeFailure(
+              productId,
+              'fetch',
+              `Product not found: ${productId}`,
+              'product_id',
+              index
+            ),
+          };
+        }
+        return { product, failure: undefined };
+      } catch (error) {
+        return {
+          product: undefined,
+          failure: {
+            key: productId,
+            index,
+            stage: 'fetch' as const,
+            errors: parsePlytixErrors(error),
+          },
+        };
+      }
+    }
+  );
+
+  for (const result of results) {
+    if (result.failure) {
+      state.failures.push(result.failure);
+      continue;
+    }
+    if (result.product) {
+      await acceptDeterministicProduct(sink, result.product, input.mode);
+    }
+  }
+}
+
+async function acceptDeterministicProduct(
+  sink: ProductExportSink,
+  product: PlytixProduct,
+  mode: 'skus' | 'product_ids'
+): Promise<void> {
+  const limitReason = await sink.accept(product);
+  if (!limitReason) return;
+
+  await sink.abort();
+  throw makeLimitError(
+    limitReason,
+    `${mode} export exceeded a hard output limit before all requested products were written`
+  );
+}
+
+async function getProductWithRetry(
+  ops: ProductExportOperations,
+  productId: string,
+  retries = 2
+): Promise<PlytixResult<PlytixProduct>> {
+  return runTransientRetry(() => ops.getProduct(productId), retries);
+}
+
+async function searchProductsWithRetry(
+  ops: ProductExportOperations,
+  body: PlytixSearchBody,
+  retries = 2
+): Promise<PlytixResult<PlytixProduct>> {
+  return runTransientRetry(() => ops.searchProducts(body), retries);
+}
+
+async function runTransientRetry<T>(fn: () => Promise<T>, retries = 2): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt < retries && isTransientError(error)) {
+        await new Promise((resolve) => setTimeout(resolve, 500 * 2 ** attempt));
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error('Transient retry loop exited unexpectedly');
+}
+
+async function validateExportInput(
+  rawInput: unknown,
+  options: ExecuteBatchExportOptions
+): Promise<ValidationResult> {
+  const failures: ProductBatchExportFailure[] = [];
+  if (!isPlainObject(rawInput)) {
+    return {
+      failures: [makeFailure('batch_export', 'validation', 'input must be an object')],
+    };
+  }
+
+  const input = rawInput as Partial<ProductBatchExportInput> & Record<string, unknown>;
+  const mode = input.mode;
+  if (mode !== 'search' && mode !== 'skus' && mode !== 'product_ids') {
+    return {
+      failures: [
+        makeFailure(
+          'batch_export',
+          'validation',
+          'mode must be one of: search, skus, product_ids',
+          'mode'
+        ),
+      ],
+    };
+  }
+
+  const attributes = normalizeAttributes(input.attributes, failures);
+  const previewRows = normalizePositiveInt(
+    input.preview_rows,
+    'preview_rows',
+    DEFAULT_EXPORT_PREVIEW_ROWS,
+    MAX_EXPORT_PREVIEW_ROWS,
+    failures
+  );
+  const pageSize = normalizePositiveInt(
+    input.page_size,
+    'page_size',
+    DEFAULT_EXPORT_PAGE_SIZE,
+    MAX_EXPORT_PAGE_SIZE,
+    failures
+  );
+  const maxRowsExplicit = input.max_rows !== undefined;
+  const rawMaxRows = normalizePositiveInt(
+    input.max_rows,
+    'max_rows',
+    undefined,
+    options.maxRows,
+    failures
+  );
+
+  if (mode !== 'search' && input.sort !== undefined) {
+    failures.push(makeFailure(mode, 'validation', 'sort is only supported for search mode', 'sort'));
+  }
+  if (mode !== 'search' && input.filters !== undefined) {
+    failures.push(
+      makeFailure(mode, 'validation', 'filters are only supported for search mode', 'filters')
+    );
+  }
+  if (mode !== 'search' && input.confirm_full_catalog !== undefined) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        'confirm_full_catalog is only supported for search mode',
+        'confirm_full_catalog'
+      )
+    );
+  }
+  if (mode === 'search' && input.skus !== undefined) {
+    failures.push(makeFailure(mode, 'validation', 'skus are only supported for skus mode', 'skus'));
+  }
+  if (mode === 'search' && input.product_ids !== undefined) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        'product_ids are only supported for product_ids mode',
+        'product_ids'
+      )
+    );
+  }
+  if (mode === 'skus' && input.product_ids !== undefined) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        'product_ids are only supported for product_ids mode',
+        'product_ids'
+      )
+    );
+  }
+  if (mode === 'product_ids' && input.skus !== undefined) {
+    failures.push(makeFailure(mode, 'validation', 'skus are only supported for skus mode', 'skus'));
+  }
+  if (mode === 'product_ids' && input.attributes !== undefined) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        'attributes are not supported for product_ids mode',
+        'attributes'
+      )
+    );
+  }
+  if (mode === 'product_ids' && input.page_size !== undefined) {
+    failures.push(
+      makeFailure(mode, 'validation', 'page_size is not supported for product_ids mode', 'page_size')
+    );
+  }
+
+  if (mode === 'search') {
+    const filters = normalizeFilters(input.filters, failures);
+    if (isEmptySearch(filters) && input.confirm_full_catalog !== true) {
+      failures.push(
+        makeFailure(
+          'search',
+          'validation',
+          'empty search requires confirm_full_catalog: true',
+          'filters'
+        )
+      );
+    }
+    if (options.mode === 'file' && !maxRowsExplicit) {
+      failures.push(
+        makeFailure('search', 'validation', 'file search export requires max_rows', 'max_rows')
+      );
+    }
+
+    const maxRows = rawMaxRows ?? options.maxRows;
+    if (failures.length > 0) return { failures };
+
+    const normalized: NormalizedInput = {
+      mode,
+      ...(filters ? { filters } : {}),
+      ...(input.sort !== undefined ? { sort: input.sort } : {}),
+      confirmFullCatalog: input.confirm_full_catalog === true,
+      ...(attributes ? { attributes } : {}),
+      maxRows,
+      maxRowsExplicit,
+      pageSize: pageSize ?? DEFAULT_EXPORT_PAGE_SIZE,
+      previewRows: previewRows ?? DEFAULT_EXPORT_PREVIEW_ROWS,
+    };
+    normalized.querySha256 = await hashQuery(normalized);
+    return { input: normalized, failures: [] };
+  }
+
+  const identifiers =
+    mode === 'skus'
+      ? normalizeIdentifierList(input.skus, 'skus', failures)
+      : normalizeIdentifierList(input.product_ids, 'product_ids', failures);
+  const requested = identifiers.length;
+  if (requested === 0) {
+    failures.push(
+      makeFailure(mode, 'validation', `${mode === 'skus' ? 'skus' : 'product_ids'} must not be empty`)
+    );
+  }
+  if (requested > options.maxRows) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        `${mode} requested ${requested} products; max is ${options.maxRows}`,
+        mode === 'skus' ? 'skus' : 'product_ids'
+      )
+    );
+  }
+  if (rawMaxRows !== undefined && rawMaxRows < requested) {
+    failures.push(
+      makeFailure(
+        mode,
+        'validation',
+        `max_rows ${rawMaxRows} is lower than requested identifier count ${requested}`,
+        'max_rows'
+      )
+    );
+  }
+  if (failures.length > 0) return { failures, requested };
+
+  const normalized: NormalizedInput =
+    mode === 'skus'
+      ? {
+          mode,
+          skus: identifiers,
+          ...(attributes ? { attributes } : {}),
+          maxRows: rawMaxRows ?? requested,
+          maxRowsExplicit,
+          pageSize: pageSize ?? DEFAULT_EXPORT_PAGE_SIZE,
+          previewRows: previewRows ?? DEFAULT_EXPORT_PREVIEW_ROWS,
+        }
+      : {
+          mode,
+          productIds: identifiers,
+          maxRows: rawMaxRows ?? requested,
+          maxRowsExplicit,
+          pageSize: DEFAULT_EXPORT_PAGE_SIZE,
+          previewRows: previewRows ?? DEFAULT_EXPORT_PREVIEW_ROWS,
+        };
+  normalized.querySha256 = await hashQuery(normalized);
+  return { input: normalized, failures: [], requested };
+}
+
+function rejectedExport(args: {
+  requested?: number;
+  matched?: number;
+  failures: ProductBatchExportFailure[];
+  startedAt: string;
+  selectorMode?: ProductBatchExportMetadata['selector_mode'];
+  querySha256?: string;
+  pageSize?: number;
+  pagesRead?: number;
+  attributesRequested?: string[];
+  limitReason?: ProductBatchExportLimitReason;
+}): ProductBatchExportResult {
+  const summary: ProductBatchExportSummary = {
+    ...(args.requested !== undefined ? { requested: args.requested } : {}),
+    ...(args.matched !== undefined ? { matched: args.matched } : {}),
+    exported: 0,
+    failed: args.failures.length,
+    truncated: false,
+    ...(args.limitReason ? { limit_reason: args.limitReason } : {}),
+  };
+  const completedAt = new Date().toISOString();
+  return {
+    status: 'rejected',
+    summary,
+    failures: args.failures,
+    ...(args.selectorMode
+      ? {
+          metadata: {
+            selector_mode: args.selectorMode,
+            row_count: 0,
+            page_size: args.pageSize ?? DEFAULT_EXPORT_PAGE_SIZE,
+            started_at: args.startedAt,
+            completed_at: completedAt,
+            ...(args.querySha256 ? { query_sha256: args.querySha256 } : {}),
+            ...(args.pagesRead ? { pages_read: args.pagesRead } : {}),
+            ...(args.attributesRequested ? { attributes_requested: args.attributesRequested } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function makeFailure(
+  key: string,
+  stage: ProductBatchExportFailure['stage'],
+  msg: string,
+  field?: string,
+  index?: number
+): ProductBatchExportFailure {
+  return {
+    key,
+    ...(index !== undefined ? { index } : {}),
+    stage,
+    errors: [{ ...(field ? { field } : {}), msg }],
+  };
+}
+
+function makeLimitError(reason: ProductBatchExportLimitReason, message: string): Error & {
+  limitReason?: ProductBatchExportLimitReason;
+  errors?: BatchUpdateErrorDetail[];
+} {
+  const error = new Error(message) as Error & {
+    limitReason?: ProductBatchExportLimitReason;
+    errors?: BatchUpdateErrorDetail[];
+  };
+  error.limitReason = reason;
+  error.errors = [{ msg: message }];
+  return error;
+}
+
+function readLimitReason(error: unknown): ProductBatchExportLimitReason | undefined {
+  if (!error || typeof error !== 'object' || !('limitReason' in error)) return undefined;
+  const reason = (error as { limitReason?: unknown }).limitReason;
+  return reason === 'max_rows' ||
+    reason === 'file_byte_cap' ||
+    reason === 'inline_row_cap' ||
+    reason === 'inline_byte_cap' ||
+    reason === 'api_window_limit'
+    ? reason
+    : undefined;
+}
+
+function readSelectorMode(rawInput: unknown): ProductBatchExportMetadata['selector_mode'] | undefined {
+  if (!isPlainObject(rawInput)) return undefined;
+  const mode = rawInput.mode;
+  return mode === 'search' || mode === 'skus' || mode === 'product_ids' ? mode : undefined;
+}
+
+function normalizeAttributes(
+  value: unknown,
+  failures: ProductBatchExportFailure[]
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    failures.push(
+      makeFailure('batch_export', 'validation', 'attributes must be an array', 'attributes')
+    );
+    return undefined;
+  }
+
+  const attributes: string[] = [];
+  const seen = new Set<string>();
+  value.forEach((attribute, index) => {
+    if (typeof attribute !== 'string' || attribute.trim() === '') {
+      failures.push(
+        makeFailure(
+          'batch_export',
+          'validation',
+          'attribute must be a non-empty string',
+          `attributes.${index}`
+        )
+      );
+      return;
+    }
+    if (seen.has(attribute)) {
+      failures.push(
+        makeFailure(
+          'batch_export',
+          'validation',
+          `duplicate attribute: ${attribute}`,
+          'attributes'
+        )
+      );
+      return;
+    }
+    seen.add(attribute);
+    attributes.push(attribute);
+  });
+
+  if (attributes.length > MAX_EXPORT_ATTRIBUTES) {
+    failures.push(
+      makeFailure(
+        'batch_export',
+        'validation',
+        `attributes has ${attributes.length} entries; max is ${MAX_EXPORT_ATTRIBUTES}`,
+        'attributes'
+      )
+    );
+  }
+
+  return attributes.length > 0 ? [...attributes].sort() : undefined;
+}
+
+function normalizeIdentifierList(
+  value: unknown,
+  field: 'skus' | 'product_ids',
+  failures: ProductBatchExportFailure[]
+): string[] {
+  if (!Array.isArray(value)) {
+    failures.push(makeFailure(field, 'validation', `${field} must be an array`, field));
+    return [];
+  }
+
+  const identifiers: string[] = [];
+  const seen = new Set<string>();
+  value.forEach((identifier, index) => {
+    if (typeof identifier !== 'string' || identifier.trim() === '') {
+      failures.push(
+        makeFailure(field, 'validation', `${field} entries must be non-empty strings`, field, index)
+      );
+      return;
+    }
+    if (seen.has(identifier)) {
+      failures.push(
+        makeFailure(identifier, 'validation', `duplicate ${field.slice(0, -1)}: ${identifier}`, field, index)
+      );
+      return;
+    }
+    seen.add(identifier);
+    identifiers.push(identifier);
+  });
+  return identifiers;
+}
+
+function normalizePositiveInt(
+  value: unknown,
+  field: string,
+  defaultValue: number | undefined,
+  max: number,
+  failures: ProductBatchExportFailure[]
+): number | undefined {
+  if (value === undefined) return defaultValue;
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    failures.push(makeFailure('batch_export', 'validation', `${field} must be a positive integer`, field));
+    return defaultValue;
+  }
+  if ((value as number) > max) {
+    failures.push(
+      makeFailure('batch_export', 'validation', `${field} must be <= ${max}`, field)
+    );
+  }
+  return value as number;
+}
+
+function normalizeFilters(
+  value: unknown,
+  failures: ProductBatchExportFailure[]
+): PlytixSearchBody['filters'] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    failures.push(makeFailure('search', 'validation', 'filters must be an array', 'filters'));
+    return undefined;
+  }
+
+  return value.map((group) => {
+    if (!Array.isArray(group)) return group;
+    return group.map((item) =>
+      Array.isArray(item) && item.length >= 2 && typeof item[0] === 'string'
+        ? { field: item[0], operator: item[1], value: item[2] }
+        : item
+    );
+  }) as PlytixSearchBody['filters'];
+}
+
+function isEmptySearch(filters: PlytixSearchBody['filters'] | undefined): boolean {
+  if (!filters || filters.length === 0) return true;
+  return filters.every((group) => Array.isArray(group) && group.length === 0);
+}
+
+function observeReturnedAttributes(
+  result: PlytixResult<PlytixProduct>,
+  observed: Set<string>
+): void {
+  for (const attribute of result.attributes ?? []) {
+    observed.add(attribute);
+  }
+}
+
+function hasMoreSearchPages(
+  result: PlytixResult<PlytixProduct>,
+  currentPage: number,
+  exported: number
+): boolean {
+  if (result.pagination?.total !== undefined && result.pagination.total > exported) {
+    return true;
+  }
+  if (result.pagination?.pages !== undefined) {
+    return currentPage < result.pagination.pages;
+  }
+  return (result.data ?? []).length > 0;
+}
+
+function getRequested(input: NormalizedInput): number | undefined {
+  if (input.mode === 'skus') return input.skus.length;
+  if (input.mode === 'product_ids') return input.productIds.length;
+  return undefined;
+}
+
+function getAttributesRequested(input: NormalizedInput): string[] | undefined {
+  if (input.mode === 'product_ids') return undefined;
+  return input.attributes;
+}
+
+async function hashQuery(input: NormalizedInput): Promise<string> {
+  const query =
+    input.mode === 'search'
+      ? {
+          mode: input.mode,
+          filters: input.filters ?? [],
+          ...(input.sort !== undefined ? { sort: input.sort } : {}),
+          attributes: input.attributes ?? [],
+          max_rows: input.maxRows,
+          page_size: input.pageSize,
+        }
+      : input.mode === 'skus'
+        ? {
+            mode: input.mode,
+            skus: input.skus,
+            attributes: input.attributes ?? [],
+            max_rows: input.maxRows,
+            page_size: input.pageSize,
+          }
+        : {
+            mode: input.mode,
+            product_ids: input.productIds,
+            max_rows: input.maxRows,
+          };
+  return sha256Hex(canonicalJson(query));
+}
+
+export function canonicalJsonLine(value: unknown): string {
+  return `${canonicalJson(value)}\n`;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(toCanonicalValue(value));
+}
+
+function toCanonicalValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('Cannot canonicalize non-finite number');
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => (item === undefined ? null : toCanonicalValue(item)));
+  }
+  if (typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(object).sort()) {
+      const canonical = toCanonicalValue(object[key]);
+      if (canonical !== undefined) {
+        output[key] = canonical;
+      }
+    }
+    return output;
+  }
+  throw new Error(`Cannot canonicalize value of type ${typeof value}`);
+}
+
+export async function sha256Hex(value: string | Uint8Array): Promise<string> {
+  const bytes = typeof value === 'string' ? new TextEncoder().encode(value) : value;
+  const digestInput = new Uint8Array(bytes.byteLength);
+  digestInput.set(bytes);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', digestInput.buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function isTransientError(error: unknown): boolean {
+  const status =
+    error && typeof error === 'object' && 'status' in error
+      ? (error as { status?: unknown }).status
+      : undefined;
+  if (typeof status === 'number') {
+    return status === 429 || status >= 500;
+  }
+  return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,6 +27,9 @@ import type {
   RateLimitInfo,
   BatchUpdateMetadata,
   BatchUpdateResult,
+  ProductBatchExportInput,
+  ProductBatchExportResult,
+  ProductBatchExportToFileInput,
 } from './types.js';
 import { PlytixError } from './types.js';
 import {
@@ -38,6 +41,13 @@ import {
   type ExecuteBatchUpdateOptions,
   type ResolvedProductRef,
 } from './batch/runner.js';
+import {
+  STDIO_EXPORT_INLINE_MAX_BYTES,
+  STDIO_EXPORT_INLINE_MAX_ROWS,
+  executeBatchExport,
+  type ExecuteBatchExportOptions,
+} from './batch/export.js';
+import { exportProductsToFile } from './batch/export-file.js';
 
 const DEFAULT_CONFIG = {
   baseUrl: 'https://pim.plytix.com',
@@ -285,6 +295,26 @@ export class PlytixClient {
       requestDelayMs: options.requestDelayMs,
       returnSuccesses: options.returnSuccesses,
     });
+  }
+
+  async batchExportProducts(
+    input: ProductBatchExportInput,
+    options: Partial<ExecuteBatchExportOptions> = {}
+  ): Promise<ProductBatchExportResult> {
+    return executeBatchExport(this, input, {
+      mode: 'inline',
+      maxRows: options.maxRows ?? STDIO_EXPORT_INLINE_MAX_ROWS,
+      maxResponseBytes: options.maxResponseBytes ?? STDIO_EXPORT_INLINE_MAX_BYTES,
+      concurrency: options.concurrency,
+      requestDelayMs: options.requestDelayMs,
+      metadata: options.metadata,
+    });
+  }
+
+  async batchExportProductsToFile(
+    input: ProductBatchExportToFileInput
+  ): Promise<ProductBatchExportResult> {
+    return exportProductsToFile(this, input);
   }
 
   async getProduct(id: string): Promise<PlytixResult<PlytixProduct>> {

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -8,7 +8,11 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PlytixClient } from '../client.js';
-import type { PlytixProduct } from '../types.js';
+import type {
+  PlytixProduct,
+  ProductBatchExportInput,
+  ProductBatchExportToFileInput,
+} from '../types.js';
 import { PlytixLookup } from '../lookup/index.js';
 import { registerTool } from './register.js';
 import type { IdentifierType } from '../lookup/identifier.js';
@@ -18,6 +22,10 @@ import {
   STDIO_INLINE_MAX_ITEMS,
 } from '../batch/helpers.js';
 import { readBatchManifest } from '../batch/manifest.js';
+import {
+  STDIO_EXPORT_INLINE_MAX_BYTES,
+  STDIO_EXPORT_INLINE_MAX_ROWS,
+} from '../batch/export.js';
 
 const batchUpdateItemSchema = z.object({
   sku: z.string().min(1).optional(),
@@ -28,6 +36,32 @@ const batchUpdateItemSchema = z.object({
   expected_attributes: z.record(z.unknown()).optional(),
   if_match: z.record(z.unknown()).optional(),
 });
+
+const batchExportShape = {
+  mode: z.enum(['search', 'skus', 'product_ids']).describe('Export selector mode'),
+  filters: z
+    .array(z.any())
+    .nullable()
+    .optional()
+    .describe('Search filters for mode: search'),
+  sort: z.any().optional().describe('Sort payload for mode: search'),
+  confirm_full_catalog: z
+    .boolean()
+    .optional()
+    .describe('Required for empty-filter search exports'),
+  skus: z.array(z.string().min(1)).optional().describe('Exact SKUs for mode: skus'),
+  product_ids: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Product IDs for mode: product_ids'),
+  attributes: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Attributes to project for search/skus mode (max 50)'),
+  max_rows: z.number().int().positive().optional().describe('Maximum rows to export'),
+  page_size: z.number().int().positive().max(100).optional().describe('Search page size'),
+  preview_rows: z.number().int().positive().max(20).optional().describe('Preview row count'),
+};
 
 export function registerProductTools(server: McpServer, client: PlytixClient) {
   // Create lookup instance for smart search
@@ -320,6 +354,85 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
             {
               type: 'text',
               text: `Error searching products: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products.batch_export - Small inline product export
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<ProductBatchExportInput & Record<string, unknown>>(
+    server,
+    'products_batch_export',
+    {
+      title: 'Batch Export Products',
+      description:
+        `Export a small product snapshot inline by search, SKU list, or product ID list ` +
+        `(max ${STDIO_EXPORT_INLINE_MAX_ROWS} rows and ${STDIO_EXPORT_INLINE_MAX_BYTES} serialized bytes).`,
+      inputSchema: batchExportShape,
+    },
+    async (args) => {
+      try {
+        const result = await client.batchExportProducts(args as ProductBatchExportInput);
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          ...(result.status === 'rejected' ? { isError: true } : {}),
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error running batch export: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─────────────────────────────────────────────────────────────
+  // products.batch_export_to_file - Stdio-only product export
+  // ─────────────────────────────────────────────────────────────
+
+  registerTool<ProductBatchExportToFileInput & Record<string, unknown>>(
+    server,
+    'products_batch_export_to_file',
+    {
+      title: 'Batch Export Products To File',
+      description:
+        'Write a product snapshot to JSONL/NDJSON under PLYTIX_MCP_EXPORT_DIR without returning all rows through the model context.',
+      inputSchema: {
+        ...batchExportShape,
+        output_path: z
+          .string()
+          .min(1)
+          .describe('Export path relative to PLYTIX_MCP_EXPORT_DIR, or absolute inside it'),
+        format: z.enum(['jsonl', 'ndjson']).optional().describe('Must match output_path extension'),
+        overwrite: z.boolean().optional().describe('Replace output_path if it already exists'),
+      },
+    },
+    async (args) => {
+      try {
+        const result = await client.batchExportProductsToFile(args as ProductBatchExportToFileInput);
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          ...(result.status === 'rejected' ? { isError: true } : {}),
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error writing batch export: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
           isError: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,105 @@ export type BatchUpdateResult =
       metadata?: BatchUpdateMetadata;
     };
 
+// ─────────────────────────────────────────────────────────────
+// Batch Product Exports
+// ─────────────────────────────────────────────────────────────
+
+export type ProductExportMode = 'search' | 'skus' | 'product_ids';
+
+export type ProductExportSelector =
+  | {
+      mode: 'search';
+      filters?: unknown[] | null;
+      sort?: unknown;
+      confirm_full_catalog?: boolean;
+    }
+  | {
+      mode: 'skus';
+      skus: string[];
+    }
+  | {
+      mode: 'product_ids';
+      product_ids: string[];
+    };
+
+export type ProductBatchExportInput = ProductExportSelector & {
+  attributes?: string[];
+  max_rows?: number;
+  page_size?: number;
+  preview_rows?: number;
+};
+
+export type ProductBatchExportFormat = 'jsonl' | 'ndjson';
+
+export type ProductBatchExportToFileInput = ProductBatchExportInput & {
+  output_path: string;
+  format?: ProductBatchExportFormat;
+  overwrite?: boolean;
+};
+
+export type ProductBatchExportLimitReason =
+  | 'max_rows'
+  | 'file_byte_cap'
+  | 'inline_row_cap'
+  | 'inline_byte_cap'
+  | 'api_window_limit';
+
+export type ProductBatchExportFailureStage =
+  | 'validation'
+  | 'resolve'
+  | 'fetch'
+  | 'write'
+  | 'limit';
+
+export interface ProductBatchExportFailure {
+  key: string;
+  index?: number;
+  stage: ProductBatchExportFailureStage;
+  errors: BatchUpdateErrorDetail[];
+}
+
+export interface ProductBatchExportSummary {
+  requested?: number;
+  matched?: number;
+  exported: number;
+  failed: number;
+  truncated: boolean;
+  limit_reason?: ProductBatchExportLimitReason;
+}
+
+export interface ProductBatchExportMetadata {
+  selector_mode: ProductExportMode;
+  output_path?: string;
+  row_count: number;
+  page_size: number;
+  pages_read?: number;
+  started_at: string;
+  completed_at: string;
+  query_sha256?: string;
+  export_sha256?: string;
+  attributes_requested?: string[];
+  attributes_returned_observed?: string[];
+  format?: ProductBatchExportFormat;
+}
+
+export type ProductBatchExportResult =
+  | {
+      status: 'rejected';
+      summary: ProductBatchExportSummary;
+      failures: ProductBatchExportFailure[];
+      metadata?: ProductBatchExportMetadata;
+    }
+  | {
+      status: 'finished';
+      mode: 'inline' | 'file';
+      products?: PlytixProduct[];
+      preview: PlytixProduct[];
+      summary: ProductBatchExportSummary;
+      failures: ProductBatchExportFailure[];
+      metadata: ProductBatchExportMetadata;
+    };
+
 export interface PlytixRelationship {
   relationship_id: string;
   relationship_label: string;

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -26,6 +26,8 @@ import type {
   RateLimitInfo,
   BatchUpdateMetadata,
   BatchUpdateResult,
+  ProductBatchExportInput,
+  ProductBatchExportResult,
 } from './types.js';
 import { PlytixError } from './types.js';
 import {
@@ -37,6 +39,12 @@ import {
   type ExecuteBatchUpdateOptions,
   type ResolvedProductRef,
 } from './batch/runner.js';
+import {
+  WORKER_EXPORT_INLINE_MAX_BYTES,
+  WORKER_EXPORT_INLINE_MAX_ROWS,
+  executeBatchExport,
+  type ExecuteBatchExportOptions,
+} from './batch/export.js';
 
 const DEFAULT_CONFIG = {
   baseUrl: 'https://pim.plytix.com',
@@ -353,6 +361,20 @@ export class WorkerPlytixClient {
       concurrency: options.concurrency,
       requestDelayMs: options.requestDelayMs,
       returnSuccesses: options.returnSuccesses,
+    });
+  }
+
+  async batchExportProducts(
+    input: ProductBatchExportInput,
+    options: Partial<ExecuteBatchExportOptions> = {}
+  ): Promise<ProductBatchExportResult> {
+    return executeBatchExport(this, input, {
+      mode: 'inline',
+      maxRows: options.maxRows ?? WORKER_EXPORT_INLINE_MAX_ROWS,
+      maxResponseBytes: options.maxResponseBytes ?? WORKER_EXPORT_INLINE_MAX_BYTES,
+      concurrency: options.concurrency,
+      requestDelayMs: options.requestDelayMs,
+      metadata: options.metadata,
     });
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,6 +15,10 @@ import { WorkerPlytixLookup } from './worker-lookup.js';
 import { stripAttributesPrefix } from './utils/attribute-labels.js';
 import { validateAttributeValue } from './utils/validate-attribute.js';
 import { WORKER_INLINE_MAX_BYTES, WORKER_INLINE_MAX_ITEMS } from './batch/helpers.js';
+import {
+  WORKER_EXPORT_INLINE_MAX_BYTES,
+  WORKER_EXPORT_INLINE_MAX_ROWS,
+} from './batch/export.js';
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -368,6 +372,61 @@ const TOOLS: ToolDefinition[] = [
           description: 'Sorting options',
         },
       },
+    },
+  },
+  {
+    name: 'products_batch_export',
+    description:
+      `Export a small product snapshot inline by search, SKU list, or product ID list ` +
+      `(max ${WORKER_EXPORT_INLINE_MAX_ROWS} rows and ${WORKER_EXPORT_INLINE_MAX_BYTES} serialized bytes).`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: {
+          type: 'string',
+          enum: ['search', 'skus', 'product_ids'],
+          description: 'Export selector mode',
+        },
+        filters: {
+          type: 'array',
+          description: 'Search filters for mode: search',
+        },
+        sort: {
+          description: 'Sort payload for mode: search',
+        },
+        confirm_full_catalog: {
+          type: 'boolean',
+          description: 'Required for empty-filter search exports',
+        },
+        skus: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Exact SKUs for mode: skus',
+        },
+        product_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Product IDs for mode: product_ids',
+        },
+        attributes: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Attributes to project for search/skus mode (max 50)',
+        },
+        max_rows: {
+          type: 'number',
+          description: 'Maximum rows to export',
+        },
+        page_size: {
+          type: 'number',
+          description: 'Search page size (max 100)',
+        },
+        preview_rows: {
+          type: 'number',
+          description: 'Preview row count (max 20)',
+        },
+      },
+      required: ['mode'],
     },
   },
   {
@@ -1137,6 +1196,17 @@ const toolHandlers: Record<string, ToolHandler> = {
           ),
         },
       ],
+    };
+  },
+
+  async products_batch_export(args, client) {
+    const result = await client.batchExportProducts(
+      args as Parameters<typeof client.batchExportProducts>[0]
+    );
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      ...(result.status === 'rejected' ? { isError: true } : {}),
     };
   },
 


### PR DESCRIPTION
## Summary
- add products_batch_export for capped inline product snapshots on stdio and Worker
- add stdio-only products_batch_export_to_file with PLYTIX_MCP_EXPORT_DIR path guardrails and canonical JSONL/NDJSON output
- document the batch export contract, Worker parity exception, and v0.3.2 release notes

## Verification
- npm test
- npm run typecheck
- npm run typecheck:worker
- npm run build
- npm run build:worker