### PR TITLE
v0.3.3 feat: nullish-equivalence guard semantics (expected null matches absent-or-null)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-06-09
+
+### Changed
+- Batch update guards: an expected `null` in `expected_attributes` / `if_match` now matches a live
+  value that is `null` **or absent** (nullish equivalence). JSON cannot express `undefined`, so
+  `null` is the only way a manifest can assert "this attribute is currently empty" — required for
+  fill-in-the-blanks (gap-fill) callers. A present empty string still does not match `null`.
+
 ## [0.3.2] - 2026-06-09
 
 ### Added

--- a/docs/features/batch-update/SPEC.md
+++ b/docs/features/batch-update/SPEC.md
@@ -83,6 +83,12 @@ Validation before any write:
   `expected_attributes` compares keys inside `product.attributes`; `if_match` compares
   top-level fields or `attributes.<label>` paths.
 
+**Null semantics (v0.3.3).** JSON cannot express `undefined`, so a guard value of `null` means
+"expect empty": it matches a live attribute that is `null` or absent. A present empty string is a
+value and does not match. Nullish equivalence applies only at the top level of the guard object —
+nested nulls compare strictly. This is the standard precondition for fill-in-the-blanks consumers
+(read empty → write) and applies to both `expected_attributes` and `if_match` paths.
+
 If any item is structurally invalid, reject the whole call and return the offending
 indices. Do not partially apply a structurally invalid batch.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plytix-mcp-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plytix-mcp-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "MCP server for Plytix PIM API integration. Enables AI assistants to read, write, and manage product data, assets, categories, and relationships.",
   "keywords": [

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -351,6 +351,77 @@ describe('executeBatchUpdate', () => {
     ]);
     expect(ops.getProduct).not.toHaveBeenCalled();
   });
+
+  it('expected null matches an ABSENT live attribute (nullish equivalence)', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: {} } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, expected_attributes: { opt_1: null } }],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+    expect(result.status).toBe('finished');
+    expect(result.summary).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
+    expect(ops.updateProduct).toHaveBeenCalled();
+  });
+
+  it('expected null matches a live null attribute', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: { opt_1: null } } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, expected_attributes: { opt_1: null } }],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+    expect(result.summary).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
+  });
+
+  it('expected null CONFLICTS with a present empty string', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: { opt_1: '' } } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, expected_attributes: { opt_1: null } }],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+    expect(result.summary).toEqual({ total: 1, succeeded: 0, failed: 1, skipped: 1 });
+    expect(result.failures[0]).toMatchObject({ stage: 'conflict' });
+    expect(result.failures[0]?.errors?.[0]?.field).toBe('expected_attributes.opt_1');
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('expected null CONFLICTS with a present live value', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: { opt_1: 'someone wrote this' } } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, expected_attributes: { opt_1: null } }],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+    expect(result.failures[0]).toMatchObject({ stage: 'conflict' });
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
+
+  it('if_match attribute paths get the same nullish equivalence', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: {} } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, if_match: { 'attributes.opt_1': null } }],
+      { maxItems: 250, requestDelayMs: 0 }
+    );
+    expect(result.summary).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
+  });
 });
 
 describe('SKU resolution pagination', () => {

--- a/src/__tests__/batch-update.test.ts
+++ b/src/__tests__/batch-update.test.ts
@@ -422,6 +422,25 @@ describe('executeBatchUpdate', () => {
     );
     expect(result.summary).toEqual({ total: 1, succeeded: 1, failed: 0, skipped: 0 });
   });
+
+  it('dry-run with a null guard passes when the attribute is absent', async () => {
+    const ops = makeOps({
+      resolved: { GUARDED: [{ id: 'product-1', sku: 'GUARDED' }] },
+      live: { 'product-1': { id: 'product-1', attributes: {} } },
+    });
+    const result = await executeBatchUpdate(
+      ops,
+      [{ sku: 'GUARDED', attributes: { opt_1: 'new' }, expected_attributes: { opt_1: null } }],
+      { maxItems: 250, dryRun: true, requestDelayMs: 0 }
+    );
+    expect(result).toMatchObject({
+      status: 'finished',
+      dry_run: true,
+      summary: { total: 1, succeeded: 0, failed: 0, skipped: 1 },
+    });
+    expect(result.failures).toEqual([]);
+    expect(ops.updateProduct).not.toHaveBeenCalled();
+  });
 });
 
 describe('SKU resolution pagination', () => {

--- a/src/batch/runner.ts
+++ b/src/batch/runner.ts
@@ -271,7 +271,7 @@ function compareExpectedAttributes(
   if (!expected) return [];
 
   return Object.entries(expected)
-    .filter(([field, value]) => !valuesEqual(product.attributes?.[field], value))
+    .filter(([field, value]) => !guardValueMatches(product.attributes?.[field], value))
     .map(([field]) => ({
       field: `expected_attributes.${field}`,
       msg: 'live attribute no longer matches expected value',
@@ -285,7 +285,7 @@ function compareIfMatch(
   if (!expected) return [];
 
   return Object.entries(expected)
-    .filter(([field, value]) => !valuesEqual(readProductPath(product, field), value))
+    .filter(([field, value]) => !guardValueMatches(readProductPath(product, field), value))
     .map(([field]) => ({
       field: `if_match.${field}`,
       msg: 'live field no longer matches expected value',
@@ -297,6 +297,13 @@ function readProductPath(product: PlytixProduct, path: string): unknown {
     return product.attributes?.[path.slice('attributes.'.length)];
   }
   return product[path];
+}
+
+function guardValueMatches(live: unknown, expected: unknown): boolean {
+  // JSON cannot express `undefined`, so a guard's `null` means "expect empty": it matches a
+  // live value that is null OR absent. A present empty string is a value and does NOT match.
+  if (expected === null) return live === null || live === undefined;
+  return valuesEqual(live, expected);
 }
 
 function valuesEqual(left: unknown, right: unknown): boolean {

--- a/src/batch/runner.ts
+++ b/src/batch/runner.ts
@@ -302,6 +302,8 @@ function readProductPath(product: PlytixProduct, path: string): unknown {
 function guardValueMatches(live: unknown, expected: unknown): boolean {
   // JSON cannot express `undefined`, so a guard's `null` means "expect empty": it matches a
   // live value that is null OR absent. A present empty string is a value and does NOT match.
+  // Nullish equivalence applies only at the TOP level of the expected object — nested nulls
+  // inside objects/arrays compare strictly via valuesEqual.
   if (expected === null) return live === null || live === undefined;
   return valuesEqual(live, expected);
 }

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -701,7 +701,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_batch_update',
     {
       title: 'Batch Update Products',
-      description: 'Update a small batch of products by product_id or sku using documented product PATCH operations.',
+      description: 'Update a small batch of products by product_id or sku using documented product PATCH operations. A null value in expected_attributes / if_match asserts the live attribute is currently empty (null or absent); a present empty string does not match.',
       inputSchema: {
         items: z
           .array(batchUpdateItemSchema)
@@ -756,7 +756,7 @@ export function registerProductTools(server: McpServer, client: PlytixClient) {
     'products_batch_update_manifest',
     {
       title: 'Batch Update Products From Manifest',
-      description: 'Read a local JSON manifest and update products without sending large payloads through the model context.',
+      description: 'Read a local JSON manifest and update products without sending large payloads through the model context. A null value in expected_attributes / if_match asserts the live attribute is currently empty (null or absent); a present empty string does not match.',
       inputSchema: {
         manifest_path: z.string().min(1).describe('Path to a schema_version: 1 JSON manifest'),
         dry_run: z

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -679,7 +679,7 @@ const TOOLS: ToolDefinition[] = [
   },
   {
     name: 'products_batch_update',
-    description: 'Update a small batch of products by product_id or sku using documented product PATCH operations.',
+    description: 'Update a small batch of products by product_id or sku using documented product PATCH operations. A null value in expected_attributes / if_match asserts the live attribute is currently empty (null or absent); a present empty string does not match.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -699,7 +699,7 @@ const TOOLS: ToolDefinition[] = [
               },
               expected_attributes: {
                 type: 'object',
-                description: 'Attribute values that must still match live product data before PATCH',
+                description: 'Attribute values that must still match live product data before PATCH. A null value in expected_attributes / if_match asserts the live attribute is currently empty (null or absent); a present empty string does not match.',
               },
               if_match: {
                 type: 'object',


### PR DESCRIPTION
## Summary
- A guard value of `null` in `expected_attributes` / `if_match` now matches a live value that is `null` **or absent** (`undefined`). Previously `valuesEqual` used `Object.is`, so `null` vs an absent attribute was a mismatch → spurious `stage: "conflict"`.
- A present empty string still does **not** match `null` (a present `""` is a value). Nullish equivalence applies at the top level of the guard object only — nested nulls compare strictly.
- Scope: guard comparison only (`valuesEqual` has no other callers); behavior shared by stdio and Worker via the common runner. Tool descriptions, batch-update SPEC, and CHANGELOG updated; version bumped to 0.3.3.

## Why
JSON cannot express `undefined`, so the v0.3.2 guard contract had no way to assert "this attribute is currently empty/absent" — the canonical precondition for any fill-in-the-blanks read-modify-write consumer (read empty → write). Without this, every gap-fill row's guard spuriously conflicts at dry-run.

## Verification
- [x] `npm test` — 78 passed (72 pre-existing + 6 new: absent/null/empty-string/value/if_match/dry-run cases)
- [x] `npm run typecheck`
- [x] `npm run typecheck:worker`
- [x] `npm run build`
- [x] `npm run build:worker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)