### PR TITLE
feat(worker): OAuth abuse hardening — rate limits, consent context, registration validation, 7-day token TTL

### DIFF
--- a/docs/remote-setup.md
+++ b/docs/remote-setup.md
@@ -194,6 +194,23 @@ curl http://localhost:8787/health
 - **HTTPS only** - All production traffic is encrypted
 - **No logging of credentials** - API keys are not logged
 
+### OAuth hardening
+
+- **Access-token TTL**: tokens issued by `/token` default to **7 days**. Override with the
+  `OAUTH_TOKEN_TTL_SECONDS` worker var (clamped to 1 hour – 30 days).
+- **Rate limits** (per client IP, KV-backed fixed window; coarse by design since KV is
+  eventually consistent): `POST /authorize` 10/5min, `POST /register` 10/hour,
+  `POST /token` 30/5min. Over-limit requests get `429` with `Retry-After`. If real abuse
+  is observed, add zone-level Cloudflare WAF rate rules on top.
+- **Registration validation**: `redirect_uris` must be 1–10 `https:` URLs (`http:` only
+  for `localhost`/`127.0.0.1`); `client_name` is truncated to 100 chars. The consent page
+  shows the requesting client's name and the redirect destination host.
+- **Emergency revocation**: there is no per-token revoke endpoint. To invalidate ALL
+  outstanding OAuth tokens at once, rotate the encryption secret:
+  `wrangler secret put OAUTH_TOKEN_SECRET` — stored credential blobs become
+  undecryptable and every client must re-authorize. Rotating the Plytix API
+  credentials themselves has the same effect at the PIM boundary.
+
 ## Troubleshooting
 
 ### "Missing Plytix API credentials"

--- a/src/__tests__/worker-oauth.test.ts
+++ b/src/__tests__/worker-oauth.test.ts
@@ -283,7 +283,7 @@ describe('OAuth authorization-code flow (encryption + TTL + PKCE)', () => {
       expires_in: number;
     };
     expect(tokenBody.token_type).toBe('bearer');
-    expect(tokenBody.expires_in).toBe(60 * 60 * 24 * 30);
+    expect(tokenBody.expires_in).toBe(60 * 60 * 24 * 7); // 7-day default TTL
 
     // Token record: encrypted blob, no plaintext, and a bounded TTL.
     const tokenRecord = kv.store.get(`token:${tokenBody.access_token}`) as string;
@@ -291,7 +291,7 @@ describe('OAuth authorization-code flow (encryption + TTL + PKCE)', () => {
     expect(tokenRecord).not.toContain(API_KEY);
     expect(tokenRecord).not.toContain(API_PASSWORD);
     const tokenPut = kv.putCalls.find((c) => c.key === `token:${tokenBody.access_token}`);
-    expect(tokenPut?.opts?.expirationTtl).toBe(60 * 60 * 24 * 30);
+    expect(tokenPut?.opts?.expirationTtl).toBe(60 * 60 * 24 * 7);
 
     // Code is one-time use (deleted on redemption).
     expect(kv.store.has(`code:${code}`)).toBe(false);
@@ -415,5 +415,196 @@ describe('MCP auth gate with OAuth tokens', () => {
     // The decrypted credentials let the request past the auth gate, so it must
     // NOT be the -32600 "Authentication required" 401.
     expect(res.status).not.toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Abuse hardening: registration validation, consent context,
+// rate limiting, configurable token TTL
+// ─────────────────────────────────────────────────────────────
+
+describe('OAuth registration validation', () => {
+  it('rejects dangerous redirect_uri schemes at registration', async () => {
+    const env = makeEnv(makeKV());
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['javascript:alert(1)'] }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_client_metadata');
+  });
+
+  it('rejects a non-array redirect_uris', async () => {
+    const env = makeEnv(makeKV());
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: 'https://claude.ai/cb' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts http://localhost redirect for local development', async () => {
+    const env = makeEnv(makeKV());
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['http://localhost:3000/cb'] }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it('truncates client_name to 100 characters', async () => {
+    const env = makeEnv(makeKV());
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: [REGISTERED_REDIRECT],
+        client_name: 'x'.repeat(300),
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { client_name: string };
+    expect(body.client_name).toHaveLength(100);
+  });
+});
+
+describe('Consent page context', () => {
+  it('shows the client name and redirect host on the authorize form', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: [REGISTERED_REDIRECT],
+        client_name: 'My Test App',
+      }),
+    });
+    const { client_id } = (await res.json()) as { client_id: string };
+
+    const challenge = await s256('verifier-consent');
+    const page = await call(
+      env,
+      `/authorize?response_type=code&client_id=${client_id}&redirect_uri=${encodeURIComponent(
+        REGISTERED_REDIRECT
+      )}&code_challenge=${challenge}&code_challenge_method=S256`
+    );
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    expect(html).toContain('My Test App');
+    expect(html).toContain('claude.ai'); // redirect destination host
+  });
+
+  it('escapes HTML in the client name (attacker-controlled input)', async () => {
+    const kv = makeKV();
+    const env = makeEnv(kv);
+    const res = await call(env, '/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: [REGISTERED_REDIRECT],
+        client_name: '<script>alert(1)</script>',
+      }),
+    });
+    const { client_id } = (await res.json()) as { client_id: string };
+
+    const challenge = await s256('verifier-xss');
+    const page = await call(
+      env,
+      `/authorize?response_type=code&client_id=${client_id}&redirect_uri=${encodeURIComponent(
+        REGISTERED_REDIRECT
+      )}&code_challenge=${challenge}&code_challenge_method=S256`
+    );
+    const html = await page.text();
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('OAuth rate limiting', () => {
+  it('rate limits POST /authorize per IP (10 per window) and isolates other IPs', async () => {
+    const env = makeEnv(makeKV());
+    const post = (ip: string) =>
+      call(env, '/authorize', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'CF-Connecting-IP': ip,
+        },
+        body: new URLSearchParams({ client_id: 'nope', redirect_uri: 'https://x.test/cb' }).toString(),
+      });
+
+    for (let i = 0; i < 10; i++) {
+      const res = await post('203.0.113.1');
+      expect(res.status).toBe(400); // invalid client, but not rate limited
+    }
+    const eleventh = await post('203.0.113.1');
+    expect(eleventh.status).toBe(429);
+    expect(eleventh.headers.get('Retry-After')).toBeTruthy();
+
+    const otherIp = await post('203.0.113.2');
+    expect(otherIp.status).toBe(400); // different IP unaffected
+  });
+
+  it('rate limits POST /register per IP (10 per hour)', async () => {
+    const env = makeEnv(makeKV());
+    const register = () =>
+      call(env, '/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': '198.51.100.7' },
+        body: JSON.stringify({ redirect_uris: [REGISTERED_REDIRECT] }),
+      });
+
+    for (let i = 0; i < 10; i++) {
+      expect((await register()).status).toBe(201);
+    }
+    expect((await register()).status).toBe(429);
+  });
+});
+
+describe('Configurable token TTL', () => {
+  it('honors OAUTH_TOKEN_TTL_SECONDS (clamped) on issued tokens', async () => {
+    stubPlytixOk();
+    const kv = makeKV();
+    const env = makeEnv(kv, { OAUTH_TOKEN_TTL_SECONDS: '7200' });
+    const clientId = await registerClient(env, [REGISTERED_REDIRECT]);
+    const verifier = 'verifier-ttl-override-abcdefghijk';
+    const challenge = await s256(verifier);
+
+    const authRes = await call(
+      env,
+      '/authorize',
+      form({
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        api_key: API_KEY,
+        api_password: API_PASSWORD,
+      })
+    );
+    expect(authRes.status).toBe(302);
+    const code = new URL(authRes.headers.get('Location') as string).searchParams.get(
+      'code'
+    ) as string;
+
+    const tokenRes = await call(
+      env,
+      '/token',
+      form({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        client_id: clientId,
+        redirect_uri: REGISTERED_REDIRECT,
+      })
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { expires_in: number };
+    expect(body.expires_in).toBe(7200);
   });
 });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -34,6 +34,8 @@ interface Env {
   // refuse to operate without this secret so credentials are never stored
   // in plaintext.
   OAUTH_TOKEN_SECRET?: string;
+  // Access-token lifetime in seconds. Default 7 days; clamped to [1 hour, 30 days].
+  OAUTH_TOKEN_TTL_SECONDS?: string;
 }
 
 interface JsonRpcRequest {
@@ -206,17 +208,124 @@ async function decryptCreds(
 // registered list. This is the control that prevents authorization codes
 // (and the credentials they unlock) from being delivered to an
 // attacker-controlled URL.
+interface ClientRegistration {
+  redirect_uris?: unknown;
+  client_name?: unknown;
+}
+
+async function getClientRegistration(
+  kv: KVNamespace,
+  clientId: string
+): Promise<ClientRegistration | null> {
+  if (!clientId) return null;
+  return (await kv.get(`client:${clientId}`, 'json')) as ClientRegistration | null;
+}
+
+function redirectUriMatches(client: ClientRegistration | null, redirectUri: string): boolean {
+  if (!client || !redirectUri || !Array.isArray(client.redirect_uris)) return false;
+  return client.redirect_uris.includes(redirectUri);
+}
+
 async function isRegisteredRedirectUri(
   kv: KVNamespace,
   clientId: string,
   redirectUri: string
 ): Promise<boolean> {
-  if (!clientId || !redirectUri) return false;
-  const client = (await kv.get(`client:${clientId}`, 'json')) as {
-    redirect_uris?: unknown;
-  } | null;
-  if (!client || !Array.isArray(client.redirect_uris)) return false;
-  return client.redirect_uris.includes(redirectUri);
+  return redirectUriMatches(await getClientRegistration(kv, clientId), redirectUri);
+}
+
+// Validate redirect URIs at registration time. Exact-match checking at
+// authorize/token time is the load-bearing control; this narrows what can be
+// registered at all: https everywhere, plain http only for local loopback
+// development. Custom app schemes are intentionally rejected until a real
+// client needs one.
+function isAcceptableRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol === 'https:') return true;
+  if (parsed.protocol === 'http:') {
+    return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+  }
+  return false;
+}
+
+// Constant-time string comparison. Not strictly required for PKCE (the
+// compared challenge already traveled in the authorize URL), but uniform
+// comparison cost is cheap hygiene for anything auth-shaped.
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  let diff = ab.length ^ bb.length;
+  const len = Math.max(ab.length, bb.length, 1);
+  for (let i = 0; i < len; i++) {
+    diff |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+// Coarse fixed-window rate limiter backed by KV. KV is eventually consistent
+// across edge locations, so this is an abuse brake, not an exact counter —
+// good enough to blunt credential-stuffing through /authorize and KV spam
+// through /register. Returns false when the caller is over the limit.
+async function rateLimit(
+  kv: KVNamespace,
+  scope: string,
+  key: string,
+  limit: number,
+  windowSeconds: number
+): Promise<boolean> {
+  const kvKey = `rl:${scope}:${key}`;
+  const now = Date.now();
+  const existing = (await kv.get(kvKey, 'json')) as { count: number; windowStart: number } | null;
+  if (!existing || now - existing.windowStart > windowSeconds * 1000) {
+    await kv.put(kvKey, JSON.stringify({ count: 1, windowStart: now }), {
+      expirationTtl: Math.max(windowSeconds * 2, 60),
+    });
+    return true;
+  }
+  if (existing.count >= limit) return false;
+  await kv.put(
+    kvKey,
+    JSON.stringify({ count: existing.count + 1, windowStart: existing.windowStart }),
+    { expirationTtl: Math.max(windowSeconds * 2, 60) }
+  );
+  return true;
+}
+
+function rateLimitedResponse(
+  windowSeconds: number,
+  corsHeaders: Record<string, string> = {}
+): Response {
+  return new Response(
+    JSON.stringify({ error: 'rate_limited', error_description: 'Too many requests' }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(windowSeconds),
+        ...corsHeaders,
+      },
+    }
+  );
+}
+
+function clientIpOf(request: Request): string {
+  return request.headers.get('CF-Connecting-IP') || 'unknown';
+}
+
+// Parse + clamp the configured access-token TTL. Default 7 days.
+function resolveTokenTtlSeconds(raw?: string): number {
+  const DEFAULT = 60 * 60 * 24 * 7;
+  const MIN = 60 * 60;
+  const MAX = 60 * 60 * 24 * 30;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(parsed)) return DEFAULT;
+  return Math.min(MAX, Math.max(MIN, parsed));
 }
 
 function escapeHtml(str: string): string {
@@ -235,10 +344,24 @@ function renderAuthorizePage(params: {
   codeChallenge: string;
   codeChallengeMethod: string;
   scope: string;
+  clientName?: string;
   error?: string;
 }): string {
   const errorHtml = params.error
     ? `<div class="error">${escapeHtml(params.error)}</div>`
+    : '';
+
+  // Show the user WHO is asking and WHERE the auth code will be sent.
+  // client_name is attacker-controlled input — always escaped.
+  const requesterName = params.clientName?.trim() ? params.clientName.trim() : 'An application';
+  let redirectHost = '';
+  try {
+    redirectHost = new URL(params.redirectUri).host;
+  } catch {
+    redirectHost = '';
+  }
+  const destinationHtml = redirectHost
+    ? `<div class="info">After you approve, an access code will be sent to <strong>${escapeHtml(redirectHost)}</strong>.</div>`
     : '';
 
   return `<!DOCTYPE html>
@@ -267,8 +390,9 @@ function renderAuthorizePage(params: {
 <body>
   <div class="card">
     <h1>Plytix MCP</h1>
-    <p class="subtitle">An application is requesting access to your Plytix PIM data.</p>
+    <p class="subtitle"><strong>${escapeHtml(requesterName)}</strong> is requesting access to your Plytix PIM data.</p>
     ${errorHtml}
+    ${destinationHtml}
     <div class="info">Enter your Plytix API credentials. They are stored securely and used only to access the Plytix API on your behalf.</div>
     <form method="POST" action="/authorize">
       <input type="hidden" name="client_id" value="${escapeHtml(params.clientId)}">
@@ -2609,8 +2733,36 @@ export default {
         );
       }
 
+      if (!(await rateLimit(env.OAUTH_KV, 'register', clientIpOf(request), 10, 3600))) {
+        return rateLimitedResponse(3600, corsHeaders);
+      }
+
       try {
         const regBody = (await request.json()) as Record<string, unknown>;
+
+        // Validate redirect_uris before storing anything: must be 1-10 strings,
+        // each https (or http on localhost). The authorize-time exact match is
+        // the primary control; this keeps junk and dangerous schemes out of KV.
+        const redirectUris = regBody.redirect_uris;
+        if (
+          !Array.isArray(redirectUris) ||
+          redirectUris.length === 0 ||
+          redirectUris.length > 10 ||
+          !redirectUris.every((u) => typeof u === 'string' && isAcceptableRedirectUri(u))
+        ) {
+          return new Response(
+            JSON.stringify({
+              error: 'invalid_client_metadata',
+              error_description:
+                'redirect_uris must be 1-10 https URLs (http allowed only for localhost)',
+            }),
+            { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+          );
+        }
+
+        const clientName =
+          typeof regBody.client_name === 'string' ? regBody.client_name.trim().slice(0, 100) : '';
+
         const clientId = generateToken(16);
         const authMethod = (regBody.token_endpoint_auth_method as string) || 'none';
         const clientSecret = authMethod === 'none' ? undefined : generateToken(32);
@@ -2618,8 +2770,8 @@ export default {
         const registration = {
           client_id: clientId,
           ...(clientSecret ? { client_secret: clientSecret } : {}),
-          redirect_uris: regBody.redirect_uris || [],
-          client_name: regBody.client_name || '',
+          redirect_uris: redirectUris,
+          client_name: clientName,
           token_endpoint_auth_method: authMethod,
           grant_types: ['authorization_code'],
           response_types: ['code'],
@@ -2685,15 +2837,19 @@ export default {
       // becomes a credential-harvesting oracle: an attacker who initiates the
       // flow with their own redirect_uri + PKCE challenge would receive an auth
       // code (and thus the victim's credentials) at a URL they control.
-      if (!(await isRegisteredRedirectUri(env.OAUTH_KV, clientId, redirectUri))) {
+      const registration = await getClientRegistration(env.OAUTH_KV, clientId);
+      if (!redirectUriMatches(registration, redirectUri)) {
         return new Response(
           JSON.stringify({ error: 'invalid_request', error_description: 'redirect_uri is not registered for this client' }),
           { status: 400, headers: { 'Content-Type': 'application/json' } }
         );
       }
 
+      const clientName =
+        typeof registration?.client_name === 'string' ? registration.client_name : '';
+
       return new Response(
-        renderAuthorizePage({ clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope }),
+        renderAuthorizePage({ clientId, redirectUri, state, codeChallenge, codeChallengeMethod, scope, clientName }),
         { headers: { 'Content-Type': 'text/html; charset=utf-8' } }
       );
     }
@@ -2712,6 +2868,12 @@ export default {
           JSON.stringify({ error: 'server_error', error_description: 'OAuth credential encryption not configured' }),
           { status: 500, headers: { 'Content-Type': 'application/json' } }
         );
+      }
+
+      // Each POST forwards submitted credentials to Plytix's auth endpoint —
+      // without a limit this is an unthrottled credential-testing oracle.
+      if (!(await rateLimit(oauthKv, 'authorize', clientIpOf(request), 10, 300))) {
+        return rateLimitedResponse(300);
       }
 
       const formData = await request.formData();
@@ -2813,6 +2975,10 @@ export default {
         );
       }
 
+      if (!(await rateLimit(env.OAUTH_KV, 'token', clientIpOf(request), 30, 300))) {
+        return rateLimitedResponse(300, corsHeaders);
+      }
+
       // Parse body (supports both form-encoded and JSON)
       let tokenParams: Record<string, string>;
       const contentType = request.headers.get('Content-Type') || '';
@@ -2873,7 +3039,7 @@ export default {
 
       // Verify PKCE (S256)
       const expectedChallenge = await computeS256(code_verifier);
-      if (expectedChallenge !== codeData.code_challenge) {
+      if (!timingSafeEqualStr(expectedChallenge, codeData.code_challenge)) {
         return new Response(
           JSON.stringify({ error: 'invalid_grant', error_description: 'PKCE verification failed' }),
           { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
@@ -2884,7 +3050,7 @@ export default {
       // from the auth code straight into the token record (same key, so no
       // decrypt/re-encrypt needed) and bound the token's lifetime.
       const accessToken = generateToken(32);
-      const TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+      const TOKEN_TTL_SECONDS = resolveTokenTtlSeconds(env.OAUTH_TOKEN_TTL_SECONDS);
       await env.OAUTH_KV.put(
         `token:${accessToken}`,
         JSON.stringify({


### PR DESCRIPTION
## Summary

Overnight /improve run, plan 003 (`plans/003-oauth-abuse-hardening.md`, landing in the companion fixes PR). The OAuth core (exact-match redirects, S256-only PKCE, one-time codes, AES-GCM creds at rest) vetted clean — this adds the missing **abuse controls**, no flow redesign.

### What changed

- **Rate limits** (KV fixed-window, per client IP): `POST /authorize` 10/5min, `POST /register` 10/hour, `POST /token` 30/5min → `429` + `Retry-After`. /authorize was an unthrottled credential-testing oracle that proxies arbitrary creds to Plytix's auth endpoint from this worker's egress IPs. Coarse by design (KV is eventually consistent); WAF rate rules can layer on top if real abuse shows up.
- **Registration validation**: `redirect_uris` must be 1–10 `https:` URLs (`http:` only for localhost loopback — custom app schemes deliberately rejected until a real client needs one); `client_name` truncated to 100 chars.
- **Consent page context**: shows the requesting `client_name` (escaped — attacker-controlled in a DCR world) and the redirect destination host, instead of the anonymous "An application…".
- **Token TTL**: 30 days → **7-day default**, configurable via `OAUTH_TOKEN_TTL_SECONDS` (clamped 1h–30d). Emergency revocation documented: rotate `OAUTH_TOKEN_SECRET` → all stored credential blobs become undecryptable.
- **Timing-safe PKCE compare** (hygiene).

### Vetting notes (what was deliberately NOT done)

- **No CSRF token on /authorize** — rejected during adversarial vetting: the form has no session/cookie ambient authority; an attacker cannot submit the victim's credentials.
- **No per-token /revoke endpoint** — deferred; coarse revocation exists (secret rotation), documented in `docs/remote-setup.md`.

## Tests

9 new cases (scheme rejection, non-array rejection, localhost allowance, name truncation, consent name+host rendering, XSS escaping, authorize+register rate limits with per-IP isolation, TTL override end-to-end). Suite: **87/87**, `typecheck:worker` clean.

## Merge notes

Independent of PR #28. Touches `src/worker.ts` OAuth regions only — no conflict with the batch tool regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)